### PR TITLE
avoid repeated registration

### DIFF
--- a/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -98,9 +98,9 @@ object SparkRuntime {
     INSTANTIATION_LOCK.synchronized {
       if (lastInstantiatedContext.get() == null) {
         new SparkRuntime(params)
+        PlatformManager.getOrCreate.register(lastInstantiatedContext.get())
       }
     }
-    PlatformManager.getOrCreate.register(lastInstantiatedContext.get())
     lastInstantiatedContext.get()
   }
 

--- a/src/main/java/streaming/core/strategy/platform/SparkStreamingRuntime.scala
+++ b/src/main/java/streaming/core/strategy/platform/SparkStreamingRuntime.scala
@@ -160,9 +160,9 @@ object SparkStreamingRuntime {
     INSTANTIATION_LOCK.synchronized {
       if (lastInstantiatedContext.get() == null) {
         new SparkStreamingRuntime(params)
+        PlatformManager.getOrCreate.register(lastInstantiatedContext.get())
       }
     }
-    PlatformManager.getOrCreate.register(lastInstantiatedContext.get())
     lastInstantiatedContext.get()
   }
 


### PR DESCRIPTION
moved PlatformManager.getOrCreate.register(lastInstantiatedContext.get()) after per runtime first creation