### PR TITLE
support connect with es.host parameter

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/ConnectAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/ConnectAdaptor.scala
@@ -16,9 +16,9 @@ class ConnectAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAd
           option += ("format" -> s.getText)
 
         case s: ExpressionContext =>
-          option += (s.identifier().getText -> cleanStr(s.STRING().getText))
+          option += (cleanStr(s.identifier().getText) -> cleanStr(s.STRING().getText))
         case s: BooleanExpressionContext =>
-          option += (s.expression().identifier().getText -> cleanStr(s.expression().STRING().getText))
+          option += (cleanStr(s.expression().identifier().getText)-> cleanStr(s.expression().STRING().getText))
         case s: DbContext =>
           ScriptSQLExec.options(s.getText, option)
         case _ =>


### PR DESCRIPTION
```
connect jdbc where driver="com.mysql.jdbc.Driver"
    and url="jdbc:mysql://127.0.0.1/alarm_test?characterEncoding=utf8"
    and `user`="root"
    and password="****"
    as db1;
```

需要支持`` 