### PR TITLE
fix exeception when start thrift

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/core/LoalSparkServiceApp.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/core/LoalSparkServiceApp.scala
@@ -9,7 +9,7 @@ object LocalSparkServiceApp {
       "-streaming.master", "local[2]",
       "-streaming.name", "god",
       "-streaming.rest", "true",
-      "-streaming.thrift", "false",
+      "-streaming.thrift", "true",
       "-streaming.platform", "spark",
       "-streaming.job.file.path", "classpath:///test/empty.json",
       "-streaming.enableHiveSupport", "true",

--- a/streamingpro-spark-2.0/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -121,7 +121,7 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
   SparkRuntime.setLastInstantiatedContext(this)
 
   override def startThriftServer: Unit = {
-    HiveThriftServer2.startWithContext(sparkSession.sqlContext.asInstanceOf[HiveContext])
+    HiveThriftServer2.startWithContext(sparkSession.sqlContext)
   }
 
   override def startHttpServer: Unit = {}

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
@@ -29,6 +29,8 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
           mode = SaveMode.ErrorIfExists
         case s: IgnoreContext =>
           mode = SaveMode.Ignore
+        case s: ColContext =>
+          writer.partitionBy(cleanStr(s.getText))
         case _ =>
       }
     }


### PR DESCRIPTION
使用thrift server时，会把SQLContext 强制转化为HIveContext,在2.2.0之后不需要了。