### PR TITLE
提交XQL时，允许设置路径的前缀

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/DslAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/DslAdaptor.scala
@@ -9,8 +9,23 @@ trait DslAdaptor {
   def parse(ctx: SqlContext): Unit
 
   def cleanStr(str: String) = {
-    if(str.startsWith("`")||str.startsWith("\""))
-    str.substring(1, str.length - 1)
+    if (str.startsWith("`") || str.startsWith("\""))
+      str.substring(1, str.length - 1)
     else str
+  }
+
+  def withPathPrefix(prefix: String, path: String): String = {
+
+    val newPath = cleanStr(path)
+    if (prefix.isEmpty) return newPath
+
+    if (path.contains("..")) {
+      throw new RuntimeException("path should not contains ..")
+    }
+    if (path.startsWith("/")) {
+      return prefix + path.substring(1, path.length)
+    }
+    return prefix + newPath
+
   }
 }

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/LoadAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/LoadAdaptor.scala
@@ -20,7 +20,9 @@ class LoadAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
           reader.format(s.getText)
 
         case s: PathContext =>
-          if (format != "jdbc") table = reader.load(cleanStr(s.getText))
+          if (format != "jdbc") {
+            table = reader.load(withPathPrefix(scriptSQLExecListener.pathPrefix, cleanStr(s.getText)))
+          }
           if (format == "jdbc") {
             val dbAndTable = cleanStr(s.getText).split("\\.")
             ScriptSQLExec.dbMapping.get(dbAndTable(0)).foreach { f =>

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
@@ -16,7 +16,7 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
           writer.format(s.getText)
 
         case s: PathContext =>
-          writer.save(cleanStr(s.getText))
+          writer.save(withPathPrefix(scriptSQLExecListener.pathPrefix , cleanStr(s.getText)))
 
         case s: TableNameContext =>
           writer = scriptSQLExecListener.sparkSession.table(s.getText).write

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/ScriptSQLExec.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/ScriptSQLExec.scala
@@ -39,10 +39,9 @@ object ScriptSQLExec {
         |load jdbc.`db1.t_report` as tr;
         |select * from tr  as new_tr;
         |save new_tr as json.`/tmp/todd`
-        |""".stripMargin
-    parse(input, new ScriptSQLExecListener(null))
+        | """.stripMargin
+    parse(input, new ScriptSQLExecListener(null, null))
     println(dbMapping)
-
 
 
   }
@@ -56,8 +55,16 @@ object ScriptSQLExec {
   }
 }
 
-class ScriptSQLExecListener(_sparkSession: SparkSession) extends DSLSQLListener {
+class ScriptSQLExecListener(_sparkSession: SparkSession, _pathPrefix: String) extends DSLSQLListener {
   def sparkSession = _sparkSession
+
+  def pathPrefix: String = {
+    if (_pathPrefix == null || _pathPrefix.isEmpty) return ""
+    if (!_pathPrefix.endsWith("/")) {
+      return _pathPrefix + "/"
+    }
+    return _pathPrefix
+  }
 
   override def exitSql(ctx: SqlContext): Unit = {
 

--- a/streamingpro-spark-2.0/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/rest/RestController.scala
@@ -68,7 +68,7 @@ class RestController extends ApplicationController {
       if (paramAsBoolean("async", false)) {
         AsyncJobRunner.run(() => {
           try {
-            ScriptSQLExec.parse(param("sql"), new ScriptSQLExecListener(sparkSession))
+            ScriptSQLExec.parse(param("sql"), new ScriptSQLExecListener(sparkSession, param("prefixPath")))
             htp.get(new Url(param("callback")), Map("stat" -> s"""success"""))
           } catch {
             case e: Exception =>
@@ -77,7 +77,7 @@ class RestController extends ApplicationController {
           }
         })
       } else {
-        ScriptSQLExec.parse(param("sql"), new ScriptSQLExecListener(sparkSession))
+        ScriptSQLExec.parse(param("sql"), new ScriptSQLExecListener(sparkSession, param("prefixPath")))
       }
 
     } catch {


### PR DESCRIPTION
比如语句

```
save overwrite new_tr as json.`todd`;
```
如果在请求的时候设置了prefixPath 参数，假设prefixPath=/tmp，那么上面的句子会被自动改写成：

```
save overwrite new_tr as json.`/tmp/todd`;
```

同时，如果你设置了prefixPath,用户在写SQL时，对应的路径不允许有".."等字符，或者以"/"开头。
