### PR TITLE
支持UDF的热注册

### DIFF
--- a/streamingpro-commons/src/main/java/streaming/common/JarUtil.scala
+++ b/streamingpro-commons/src/main/java/streaming/common/JarUtil.scala
@@ -1,0 +1,19 @@
+package streaming.common
+
+import java.io.File
+import java.net.{URI, URL, URLClassLoader}
+
+
+/**
+  * Created by allwefantasy on 20/9/2017.
+  */
+object JarUtil {
+  def loadJar(path: String) = {
+    val uri = new URI(path).toURL
+    val classLoader = ClassLoader.getSystemClassLoader().asInstanceOf[URLClassLoader]
+    val method = classOf[URLClassLoader].getDeclaredMethod("addURL", classOf[URL])
+    method.setAccessible(true)
+    method.invoke(classLoader, uri)
+  }
+}
+

--- a/streamingpro-spark-2.0/src/main/java/streaming/core/LoalSparkServiceApp.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/core/LoalSparkServiceApp.scala
@@ -9,7 +9,7 @@ object LocalSparkServiceApp {
       "-streaming.master", "local[2]",
       "-streaming.name", "god",
       "-streaming.rest", "true",
-      "-streaming.thrift", "true",
+      "-streaming.thrift", "false",
       "-streaming.platform", "spark",
       "-streaming.job.file.path", "classpath:///test/empty.json",
       "-streaming.enableHiveSupport", "true",


### PR DESCRIPTION
可以通过Rest接口完成UDF函数注册。

http://127.0.0.1:9003/udf

参数：

path = file:///Users/allwefantasy/CSDNWorkSpace/streamingpro-udf/target/streamingpro-udf-1.0-SNAPSHOT.jar
className = streaming.core.compositor.spark.udf.F2

之后就可以在

http://127.0.0.1:9003/run/sql

sql = select sleep2(2000)

结果为：

```
[
    {
        "UDF:sleep2(cast(1000 as bigint))": ""
    }
]
```
