### PR TITLE
允许用户自定义类型

### DIFF
--- a/streamingpro-hbase/src/main/java/org/apache/spark/sql/execution/datasources/hbase/DefaultSource.scala
+++ b/streamingpro-hbase/src/main/java/org/apache/spark/sql/execution/datasources/hbase/DefaultSource.scala
@@ -126,7 +126,15 @@ case class InsertHBaseRelation(
       otherFields.foreach { field =>
         if (row.get(field._2) != null) {
           val st = field._1
-
+          val datatype = if (parameters.contains(s"field.type.${st.name}")) {
+            //StringType
+            val name = parameters(s"field.type.${st.name}")
+            name match {
+              case "StringType" => DataTypes.StringType
+              case "BinaryType" => DataTypes.BinaryType
+              case _ => DataTypes.StringType
+            }
+          } else st.dataType
           val c = st.dataType match {
             case StringType => Bytes.toBytes(row.getString(field._2))
             case FloatType => Bytes.toBytes(row.getFloat(field._2))
@@ -141,6 +149,8 @@ case class InsertHBaseRelation(
             //            case DecimalType.BigIntDecimal => Bytes.toBytes(row.getDecimal(field._2))
             case _ => Bytes.toBytes(row.getString(field._2))
           }
+
+
 
           put.addColumn(Bytes.toBytes(f), Bytes.toBytes(field._1.name), c)
         }


### PR DESCRIPTION
```
select "a" as id, "b" as ck, 1 as jk
as      
wq_tmp_test2
;
save overwrite wq_tmp_test2 
as hbase.`wq_tmp_test1`  options  rowkey="id" and `field.type.ck`="BinaryType";
```