### PR TITLE
存储为hive表时，可以指定格式

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
@@ -57,7 +57,9 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
     }
     writer = writer.options(option)
     format match {
-      case "hive" => writer.saveAsTable(final_path)
+      case "hive" =>
+        writer.format(option.getOrElse("file_format", "parquet"))
+        writer.saveAsTable(final_path)
       case "kafka8" | "kafka9" =>
         writer.option("topics", final_path).format("com.hortonworks.spark.sql.kafka08").save()
       case "hbase" =>


### PR DESCRIPTION
```
select "a" as id, "b" as ck, bin(1) as jk
as      
wq_tmp_test2
;
save overwrite wq_tmp_test2 
as hive.`wq_tmp_test3`  options  file_format="orc" 
```