### PR TITLE
SQLLDA support

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/RegisterAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/RegisterAdaptor.scala
@@ -25,7 +25,7 @@ class RegisterAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslA
     val alg = AlgMapping.findAlg(format)
     val sparkSession = scriptSQLExecListener.sparkSession
     val model = alg.load(sparkSession, path)
-    val udf = alg.predict(sparkSession, model)
+    val udf = alg.predict(sparkSession, model, functionName)
     scriptSQLExecListener.sparkSession.udf.register(functionName, udf)
   }
 }

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -37,7 +37,9 @@ object AlgMapping {
   val mapping = Map[String, String](
     "Word2vec" -> "streaming.dsl.mmlib.algs.SQLWord2Vec",
     "NaiveBayes" -> "streaming.dsl.mmlib.algs.SQLNaiveBayes",
-    "RandomForest" -> "streaming.dsl.mmlib.algs.SQLRandomForest"
+    "RandomForest" -> "streaming.dsl.mmlib.algs.SQLRandomForest",
+    "GBTRegressor" -> "streaming.dsl.mmlib.algs.SQLGBTRegressor",
+    "LDA" -> "streaming.dsl.mmlib.algs.SQLLDA"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/SQLAlg.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/SQLAlg.scala
@@ -12,7 +12,7 @@ trait SQLAlg {
 
   def load(sparkSession: SparkSession, path: String): Any
 
-  def predict(sparkSession: SparkSession, _model: Any): UserDefinedFunction
+  def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction
 
 
 }

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLGBTRegressor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLGBTRegressor.scala
@@ -26,7 +26,7 @@ class SQLGBTRegressor extends SQLAlg with Functions {
     model
   }
 
-  override def predict(sparkSession: SparkSession, _model: Any): UserDefinedFunction = {
+  override def predict(sparkSession: SparkSession, _model: Any,name:String): UserDefinedFunction = {
     val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[GBTRegressionModel])
 
     val f = (vec: Vector) => {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLLDA.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLLDA.scala
@@ -1,0 +1,53 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.SparkContext
+import org.apache.spark.ml.clustering.{LDA, LocalLDAModel}
+import org.apache.spark.ml.linalg.SQLDataTypes._
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.mllib.linalg.{Vector => OldVector, Vectors => OldVectors}
+import streaming.dsl.mmlib.SQLAlg
+import org.apache.spark.sql._
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.{DoubleType, IntegerType}
+import org.apache.spark.mllib.clustering.{DistributedLDAModel => OldDistributedLDAModel,
+EMLDAOptimizer => OldEMLDAOptimizer, LDA => OldLDA, LDAModel => OldLDAModel,
+LDAOptimizer => OldLDAOptimizer, LocalLDAModel => OldLocalLDAModel,
+OnlineLDAOptimizer => OldOnlineLDAOptimizer}
+
+/**
+  * Created by allwefantasy on 13/1/2018.
+  */
+class SQLLDA extends SQLAlg with Functions {
+
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val rfc = new LDA()
+    configureModel(rfc, params)
+    val model = rfc.fit(df)
+    model.write.overwrite().save(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    val model = LocalLDAModel.load(path)
+    model
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[LocalLDAModel])
+    val field = model.value.getClass.getDeclaredField("oldLocalModel")
+    field.setAccessible(true)
+    val oldLocalModel = field.get(model.value).asInstanceOf[OldLocalLDAModel]
+    val transformer = oldLocalModel.getClass.getMethod("getTopicDistributionMethod", classOf[SparkContext]).
+      invoke(oldLocalModel, sparkSession.sparkContext).
+      asInstanceOf[(org.apache.spark.mllib.linalg.Vector) => org.apache.spark.mllib.linalg.Vector]
+
+    sparkSession.udf.register(name + "_doc", (v: Vector) => {
+      transformer(OldVectors.fromML(v)).asML
+    })
+
+    val f = (word: Int) => {
+
+      model.value.topicsMatrix.rowIter.toList(word)
+    }
+    UserDefinedFunction(f, VectorType, Some(Seq(IntegerType)))
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLNaiveBayes.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLNaiveBayes.scala
@@ -23,7 +23,7 @@ class SQLNaiveBayes extends SQLAlg with Functions {
     model
   }
 
-  override def predict(sparkSession: SparkSession, _model: Any): UserDefinedFunction = {
+  override def predict(sparkSession: SparkSession, _model: Any,name:String): UserDefinedFunction = {
     val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[NaiveBayesModel])
 
     val f = (vec: Vector) => {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLRandomForest.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLRandomForest.scala
@@ -24,7 +24,7 @@ class SQLRandomForest extends SQLAlg with Functions {
     model
   }
 
-  override def predict(sparkSession: SparkSession, _model: Any): UserDefinedFunction = {
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
     val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[RandomForestClassificationModel])
 
     val f = (vec: Vector) => {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLWord2Vec.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLWord2Vec.scala
@@ -28,7 +28,7 @@ class SQLWord2Vec extends SQLAlg with Functions {
       toMap
   }
 
-  def predict(sparkSession: SparkSession, _model: Any): UserDefinedFunction = {
+  def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
     val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[Map[String, Array[Double]]])
 
     val f = (co: String) => {


### PR DESCRIPTION
```
load libsvm.`/Users/allwefantasy/Softwares/spark-2.2.0-bin-hadoop2.7/data/mllib/sample_lda_libsvm_data.txt` as data;
train data as LDA.`/tmp/model` where k="10" and maxIter="10";
register LDA.`/tmp/model` as predict;
select predict_doc(features)  from data as result;
save overwrite result as json.`/tmp/result`;
```

这里，我们把LDA模型注册为名字叫‘predict’的方法，系统还会自动为你生成一个叫'predict_doc'的方法。

predict方法是你给定一个词的标号，返回这个词的主题分布给你。
predict_doc 则是你给定一个组词，返回这组词的主题分布给你。