### PR TITLE
SQLKmeans,SQLFPGrowth Support

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -39,7 +39,8 @@ object AlgMapping {
     "NaiveBayes" -> "streaming.dsl.mmlib.algs.SQLNaiveBayes",
     "RandomForest" -> "streaming.dsl.mmlib.algs.SQLRandomForest",
     "GBTRegressor" -> "streaming.dsl.mmlib.algs.SQLGBTRegressor",
-    "LDA" -> "streaming.dsl.mmlib.algs.SQLLDA"
+    "LDA" -> "streaming.dsl.mmlib.algs.SQLLDA",
+    "KMeans" -> "streaming.dsl.mmlib.algs.SQLKMeans"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -40,7 +40,8 @@ object AlgMapping {
     "RandomForest" -> "streaming.dsl.mmlib.algs.SQLRandomForest",
     "GBTRegressor" -> "streaming.dsl.mmlib.algs.SQLGBTRegressor",
     "LDA" -> "streaming.dsl.mmlib.algs.SQLLDA",
-    "KMeans" -> "streaming.dsl.mmlib.algs.SQLKMeans"
+    "KMeans" -> "streaming.dsl.mmlib.algs.SQLKMeans",
+    "FPGrowth" -> "streaming.dsl.mmlib.algs.SQLFPGrowth"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLFPGrowth.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLFPGrowth.scala
@@ -1,0 +1,49 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.ml.fpm.{FPGrowth, FPGrowthModel}
+import org.apache.spark.ml.linalg.SQLDataTypes._
+import streaming.dsl.mmlib.SQLAlg
+import org.apache.spark.sql.{SparkSession, _}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.{ArrayType, IntegerType, ObjectType, StringType}
+
+/**
+  * Created by allwefantasy on 14/1/2018.
+  */
+class SQLFPGrowth extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val rfc = new FPGrowth()
+    configureModel(rfc, params)
+    val model = rfc.fit(df)
+    model.write.overwrite().save(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    val model = FPGrowthModel.load(path)
+    model
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    val model = _model.asInstanceOf[FPGrowthModel]
+    val rules: Array[(Seq[String], Seq[String])] = model.associationRules.select("antecedent", "consequent")
+      .rdd.map(r => (r.getSeq(0), r.getSeq(1)))
+      .collect().asInstanceOf[Array[(Seq[String], Seq[String])]]
+    val brRules = sparkSession.sparkContext.broadcast(rules)
+
+
+    val f = (items: Seq[String]) => {
+      if (items != null) {
+        val itemset = items.toSet
+        brRules.value.flatMap(rule =>
+          if (items != null && rule._1.forall(item => itemset.contains(item))) {
+            rule._2.filter(item => !itemset.contains(item))
+          } else {
+            Seq.empty
+          }).distinct
+      } else {
+        Seq.empty
+      }
+    }
+    UserDefinedFunction(f, ArrayType(StringType), Some(Seq(ArrayType(StringType))))
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLKMeans.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLKMeans.scala
@@ -1,0 +1,35 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.ml.clustering.{BisectingKMeans, BisectingKMeansModel}
+import org.apache.spark.ml.linalg.SQLDataTypes._
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.IntegerType
+import streaming.dsl.mmlib.SQLAlg
+
+/**
+  * Created by allwefantasy on 14/1/2018.
+  */
+class SQLKMeans extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val rfc = new BisectingKMeans()
+    configureModel(rfc, params)
+    val model = rfc.fit(df)
+    model.write.overwrite().save(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    val model = BisectingKMeansModel.load(path)
+    model
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[BisectingKMeansModel])
+    val f = (v: Vector) => {
+      model.value.getClass.getDeclaredMethod("predict", classOf[Vector]).invoke(model.value, v).asInstanceOf[Int]
+    }
+    UserDefinedFunction(f, IntegerType, Some(Seq(VectorType)))
+  }
+}


### PR DESCRIPTION
Kmeans:

```
load libsvm.`/Users/allwefantasy/Softwares/spark-2.2.0-bin-hadoop2.7/data/mllib/sample_kmeans_data.txt` as data;
train data as KMeans.`/tmp/model` where k="10";
register KMeans.`/tmp/model` as predict;
select predict(features)  from data as result;
save overwrite result as json.`/tmp/result`;
```

FPGrowth:

```
load csv.`/tmp/abc.csv` options header="True" as data;
select split(body," ") as items from data as new_dt;
train new_dt as FPGrowth.`/tmp/model` where minSupport="0.5" and minConfidence="0.6" and itemsCol="items";
register FPGrowth.`/tmp/model` as predict;
select predict(items)  from new_dt as result;
save overwrite result as json.`/tmp/result`;
```

