### PR TITLE
添加字符串转数字功能

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ml/help/HSQLStringIndex.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ml/help/HSQLStringIndex.scala
@@ -1,0 +1,49 @@
+package org.apache.spark.ml.help
+
+import org.apache.spark.SparkException
+import org.apache.spark.ml.feature.{StringIndexer, StringIndexerModel}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType}
+import org.apache.spark.util.collection.OpenHashMap
+
+/**
+  * Created by allwefantasy on 15/1/2018.
+  */
+object HSQLStringIndex {
+  def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+
+    val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[StringIndexerModel])
+
+    val f = (label: String) => {
+
+      val labelToIndexField = model.value.getClass.getDeclaredField("org$apache$spark$ml$feature$StringIndexerModel$$labelToIndex")
+      labelToIndexField.setAccessible(true)
+      val labelToIndex = labelToIndexField.get(model.value).asInstanceOf[OpenHashMap[String, Double]]
+
+      if (label == null) {
+        if (model.value.getHandleInvalid == "keep") {
+          model.value.labels.length
+        } else {
+          throw new SparkException("StringIndexer encountered NULL value. To handle or skip " +
+            "NULLS, try setting StringIndexer.handleInvalid.")
+        }
+      } else {
+        if (labelToIndex.contains(label)) {
+          labelToIndex(label)
+        } else if (model.value.getHandleInvalid == "keep") {
+          model.value.labels.length
+        } else {
+          throw new SparkException(s"Unseen label: $label.  To handle unseen labels, " +
+            s"set Param handleInvalid to keep.")
+        }
+      }
+    }
+
+    sparkSession.udf.register(name + "_r", (index: Int) => {
+      model.value.labels(index)
+    })
+
+    UserDefinedFunction(f, DoubleType, Some(Seq(StringType)))
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -41,7 +41,8 @@ object AlgMapping {
     "GBTRegressor" -> "streaming.dsl.mmlib.algs.SQLGBTRegressor",
     "LDA" -> "streaming.dsl.mmlib.algs.SQLLDA",
     "KMeans" -> "streaming.dsl.mmlib.algs.SQLKMeans",
-    "FPGrowth" -> "streaming.dsl.mmlib.algs.SQLFPGrowth"
+    "FPGrowth" -> "streaming.dsl.mmlib.algs.SQLFPGrowth",
+    "StringIndex" -> "streaming.dsl.mmlib.algs.SQLStringIndex"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLStringIndex.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLStringIndex.scala
@@ -1,0 +1,28 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.ml.feature.{StringIndexer, StringIndexerModel}
+import org.apache.spark.ml.help.HSQLStringIndex
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import streaming.dsl.mmlib.SQLAlg
+
+/**
+  * Created by allwefantasy on 15/1/2018.
+  */
+class SQLStringIndex extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val rfc = new StringIndexer()
+    configureModel(rfc, params)
+    val model = rfc.fit(df)
+    model.write.overwrite().save(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    val model = StringIndexerModel.load(path)
+    model
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    HSQLStringIndex.predict(sparkSession, _model, name)
+  }
+}


### PR DESCRIPTION
```
load csv.`/tmp/abc.csv` options header="True" as data;
select explode(split(body," ")) as word from data as new_dt;
train new_dt as StringIndex.`/tmp/model` where inputCol="word";
register StringIndex.`/tmp/model` as predict;
select predict_r(1)  from new_dt as result;
save overwrite result as json.`/tmp/result`;
```

支持将任意一列字符串生成唯一的递增数字。提供了两个函数：

predict(你注册的名字)， 给定一个字符返回一个数字。
predict_r,给定一个数字，返回对应的字符。