### PR TITLE
add LSVM and GBTs support

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -42,7 +42,9 @@ object AlgMapping {
     "LDA" -> "streaming.dsl.mmlib.algs.SQLLDA",
     "KMeans" -> "streaming.dsl.mmlib.algs.SQLKMeans",
     "FPGrowth" -> "streaming.dsl.mmlib.algs.SQLFPGrowth",
-    "StringIndex" -> "streaming.dsl.mmlib.algs.SQLStringIndex"
+    "StringIndex" -> "streaming.dsl.mmlib.algs.SQLStringIndex",
+    "GBTs" -> "streaming.dsl.mmlib.algs.SQLGBTs",
+    "LSVM" -> "streaming.dsl.mmlib.algs.SQLLSVM"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLGBTs.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLGBTs.scala
@@ -1,0 +1,38 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.ml.classification.{GBTClassificationModel, GBTClassifier}
+import org.apache.spark.ml.linalg.SQLDataTypes._
+import org.apache.spark.ml.linalg.Vector
+import streaming.dsl.mmlib.SQLAlg
+import org.apache.spark.sql.{SparkSession, _}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+
+/**
+  * Created by allwefantasy on 15/1/2018.
+  */
+class SQLGBTs extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val bayes = new GBTClassifier()
+    configureModel(bayes, params)
+    val model = bayes.fit(df)
+    model.write.overwrite().save(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    val model = GBTClassificationModel.load(path)
+    model
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[GBTClassificationModel])
+
+    val f = (vec: Vector) => {
+      val predictRaw = model.value.getClass.getMethod("predictRaw", classOf[Vector]).invoke(model.value, vec).asInstanceOf[Vector]
+      val raw2probability = model.value.getClass.getMethod("raw2probability", classOf[Vector]).invoke(model.value, predictRaw).asInstanceOf[Vector]
+      //model.getClass.getMethod("probability2prediction", classOf[Vector]).invoke(model, raw2probability).asInstanceOf[Vector]
+      raw2probability
+
+    }
+    UserDefinedFunction(f, VectorType, Some(Seq(VectorType)))
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLLSVM.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLLSVM.scala
@@ -1,0 +1,39 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.ml.classification.{GBTClassificationModel, GBTClassifier, LinearSVC, LinearSVCModel}
+import org.apache.spark.ml.linalg.SQLDataTypes._
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.DoubleType
+import streaming.dsl.mmlib.SQLAlg
+import org.apache.spark.sql.{SparkSession, _}
+
+/**
+  * Created by allwefantasy on 15/1/2018.
+  */
+class SQLLSVM extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val bayes = new LinearSVC()
+    configureModel(bayes, params)
+    val model = bayes.fit(df)
+    model.write.overwrite().save(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    val model = LinearSVCModel.load(path)
+    model
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[LinearSVCModel])
+
+    val f = (vec: Vector) => {
+      val predictRaw = model.value.getClass.getMethod("predictRaw", classOf[Vector]).invoke(model.value, vec).asInstanceOf[Vector]
+      val raw2probability = model.value.getClass.getMethod("raw2prediction", classOf[Vector]).invoke(model.value, predictRaw).asInstanceOf[Double]
+      //model.getClass.getMethod("probability2prediction", classOf[Vector]).invoke(model, raw2probability).asInstanceOf[Vector]
+      raw2probability
+
+    }
+    UserDefinedFunction(f, DoubleType, Some(Seq(VectorType)))
+  }
+}


### PR DESCRIPTION
GBTs:

```
load libsvm.`/Users/allwefantasy/Softwares/spark-2.2.0-bin-hadoop2.7/data/mllib/sample_libsvm_data.txt` as data;
train data as GBTs.`/tmp/model`;
register GBTs.`/tmp/model` as predict;
select predict(features)  from data as result;
save overwrite result as json.`/tmp/result`;
```


LSVM:

```
load libsvm.`/Users/allwefantasy/Softwares/spark-2.2.0-bin-hadoop2.7/data/mllib/sample_libsvm_data.txt` as data;
train data as LSVM.`/tmp/model` where maxIter="10" and regParam="0.1";
register LSVM.`/tmp/model` as predict;
select predict(features)  from data as result;
save overwrite result as json.`/tmp/result`;
```