### PR TITLE
tfidf support

### DIFF
--- a/streamingpro-spark-2.0/pom.xml
+++ b/streamingpro-spark-2.0/pom.xml
@@ -138,6 +138,12 @@
             <groupId>streaming.king</groupId>
             <artifactId>streamingpro-hbase</artifactId>
             <version>${parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -44,7 +44,8 @@ object AlgMapping {
     "FPGrowth" -> "streaming.dsl.mmlib.algs.SQLFPGrowth",
     "StringIndex" -> "streaming.dsl.mmlib.algs.SQLStringIndex",
     "GBTs" -> "streaming.dsl.mmlib.algs.SQLGBTs",
-    "LSVM" -> "streaming.dsl.mmlib.algs.SQLLSVM"
+    "LSVM" -> "streaming.dsl.mmlib.algs.SQLLSVM",
+    "TfIdf" -> "streaming.dsl.mmlib.algs.SQLTfIdf"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/Functions.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/Functions.scala
@@ -17,6 +17,7 @@ trait Functions {
           case i if i.isAssignableFrom(classOf[Int]) => v.toInt
           case i if i.isAssignableFrom(classOf[Double]) => v.toDouble
           case i if i.isAssignableFrom(classOf[Float]) => v.toFloat
+          case i if i.isAssignableFrom(classOf[Boolean]) => v.toBoolean
           case _ => v
         }
         m.invoke(model, v2.asInstanceOf[AnyRef])

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLTfIdf.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLTfIdf.scala
@@ -1,0 +1,50 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.ml.feature.{HashingTF, IDF, IDFModel}
+import org.apache.spark.ml.linalg.SQLDataTypes._
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.mllib.feature
+import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
+import streaming.dsl.mmlib.SQLAlg
+import org.apache.spark.sql.{SparkSession, _}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.{ArrayType, StringType}
+
+
+/**
+  * Created by allwefantasy on 17/1/2018.
+  */
+class SQLTfIdf extends SQLAlg with Functions {
+
+
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val rfc = new HashingTF()
+    configureModel(rfc, params)
+    rfc.setOutputCol("__SQLTfIdf__")
+    val featurizedData = rfc.transform(df)
+    rfc.getBinary
+    val idf = new IDF()
+    configureModel(idf, params)
+    idf.setInputCol("__SQLTfIdf__")
+    val idfModel = idf.fit(featurizedData)
+    idfModel.write.overwrite().save(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    val model = IDFModel.load(path)
+    model
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[IDFModel])
+    val hashingTF = new feature.HashingTF(model.value.idf.size).setBinary(true)
+    val idf = (words: Seq[String]) => {
+      val idfModelField = model.value.getClass.getField("org$apache$spark$ml$feature$IDFModel$$idfModel")
+      idfModelField.setAccessible(true)
+      val idfModel = idfModelField.get(model.value).asInstanceOf[feature.IDFModel]
+      val vec = hashingTF.transform(words)
+      idfModel.transform(vec).asML
+    }
+    UserDefinedFunction(idf, VectorType, Some(Seq(ArrayType(StringType))))
+  }
+}


### PR DESCRIPTION
下面是一个完整的结合tfidf/lda的使用例子：

```sql
--  tfidf/lda
--  加载文本数据
load csv.`/tmp/test.csv` options header="True" 
as zhuhl_ct;

--分词
select split(body," ") as words from zhuhl_ct 
as zhuhl_new_ct;

-- 训练一个tfidf模型
train zhuhl_new_ct as TfIdf.`/tmp/zhuhl_tfidf_model` where 
inputCol="words"
and numFeatures="100" 
and binary="true";

--注册tfidf模型
register TfIdf.`/tmp/zhuhl_tfidf_model` as zhuhl_tfidf_predict;

--将文本转化为tf/idf向量
select zhuhl_tfidf_predict(words) as features,words from zhuhl_new_ct
as lda_data;

--训练lda模型
train lda_data as LDA.`/tmp/zhuhl_lda_model` where 
 inputCol="features"
 and k="10" 
 and maxIter="10";

--注册lda预测函数
register LDA.`/tmp/zhuhl_lda_model` as zhuhl_lda_predict;

-- 将预测每个文档的主题分布
select words,zhuhl_lda_predict_doc(features) from lda_data 
as result;
save overwrite result as json.`/tmp/result`;

```