### PR TITLE
add IntTF/IDF support

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ml/feature/IntTF.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ml/feature/IntTF.scala
@@ -1,0 +1,106 @@
+package org.apache.spark.ml.feature
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
+import org.apache.spark.ml.util._
+import org.apache.spark.mllib.feature
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.{ArrayType, StructType}
+
+/**
+  * Maps a sequence of terms to their term frequencies using the hashing trick.
+  * Currently we use Austin Appleby's MurmurHash 3 algorithm (MurmurHash3_x86_32)
+  * to calculate the hash code value for the term object.
+  * Since a simple modulo is used to transform the hash function to a column index,
+  * it is advisable to use a power of two as the numFeatures parameter;
+  * otherwise the features will not be mapped evenly to the columns.
+  */
+@Since("1.2.0")
+class IntTF @Since("1.4.0")(@Since("1.4.0") override val uid: String)
+  extends Transformer with HasInputCol with HasOutputCol with DefaultParamsWritable {
+
+  @Since("1.2.0")
+  def this() = this(Identifiable.randomUID("streamingProTF"))
+
+  /** @group setParam */
+  @Since("1.4.0")
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  /** @group setParam */
+  @Since("1.4.0")
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /**
+    * Number of features. Should be greater than 0.
+    * (default = 2^18^)
+    *
+    * @group param
+    */
+  @Since("1.2.0")
+  val numFeatures = new IntParam(this, "numFeatures", "number of features (> 0)",
+    ParamValidators.gt(0))
+
+  /**
+    * Binary toggle to control term frequency counts.
+    * If true, all non-zero counts are set to 1.  This is useful for discrete probabilistic
+    * models that model binary events rather than integer counts.
+    * (default = false)
+    *
+    * @group param
+    */
+  @Since("2.0.0")
+  val binary = new BooleanParam(this, "binary", "If true, all non zero counts are set to 1. " +
+    "This is useful for discrete probabilistic models that model binary events rather " +
+    "than integer counts")
+
+  setDefault(numFeatures -> (1 << 18), binary -> false)
+
+  /** @group getParam */
+  @Since("1.2.0")
+  def getNumFeatures: Int = $(numFeatures)
+
+  /** @group setParam */
+  @Since("1.2.0")
+  def setNumFeatures(value: Int): this.type = set(numFeatures, value)
+
+  /** @group getParam */
+  @Since("2.0.0")
+  def getBinary: Boolean = $(binary)
+
+  /** @group setParam */
+  @Since("2.0.0")
+  def setBinary(value: Boolean): this.type = set(binary, value)
+
+  @Since("2.0.0")
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val outputSchema = transformSchema(dataset.schema)
+    val intTF = new feature.IntTF($(numFeatures)).setBinary($(binary))
+    // TODO: Make the hashingTF.transform natively in ml framework to avoid extra conversion.
+    val t = udf { terms: Seq[Int] => intTF.transform(terms).asML }
+    val metadata = outputSchema($(outputCol)).metadata
+    dataset.select(col("*"), t(col($(inputCol))).as($(outputCol), metadata))
+  }
+
+  @Since("1.4.0")
+  override def transformSchema(schema: StructType): StructType = {
+    val inputType = schema($(inputCol)).dataType
+    require(inputType.isInstanceOf[ArrayType],
+      s"The input column must be ArrayType, but got $inputType.")
+    val attrGroup = new AttributeGroup($(outputCol), $(numFeatures))
+    SchemaUtils.appendColumn(schema, attrGroup.toStructField())
+  }
+
+  @Since("1.4.1")
+  override def copy(extra: ParamMap): HashingTF = defaultCopy(extra)
+}
+
+@Since("1.6.0")
+object IntTF extends DefaultParamsReadable[IntTF] {
+
+  @Since("1.6.0")
+  override def load(path: String): IntTF = super.load(path)
+}

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ml/help/HSQLStringIndex.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ml/help/HSQLStringIndex.scala
@@ -22,17 +22,17 @@ object HSQLStringIndex {
       val labelToIndex = labelToIndexField.get(model.value).asInstanceOf[OpenHashMap[String, Double]]
 
       if (label == null) {
-        if (model.value.getHandleInvalid == "keep") {
-          model.value.labels.length
+        if (model.value.getHandleInvalid == "keep" || model.value.getHandleInvalid == "skip") {
+          -1
         } else {
           throw new SparkException("StringIndexer encountered NULL value. To handle or skip " +
             "NULLS, try setting StringIndexer.handleInvalid.")
         }
       } else {
         if (labelToIndex.contains(label)) {
-          labelToIndex(label)
-        } else if (model.value.getHandleInvalid == "keep") {
-          model.value.labels.length
+          labelToIndex(label).toInt
+        } else if (model.value.getHandleInvalid == "keep" || model.value.getHandleInvalid == "skip") {
+          -1
         } else {
           throw new SparkException(s"Unseen label: $label.  To handle unseen labels, " +
             s"set Param handleInvalid to keep.")
@@ -40,8 +40,27 @@ object HSQLStringIndex {
       }
     }
 
-    sparkSession.udf.register(name + "_r", (index: Double) => {
-      model.value.labels(index.toInt)
+    val f2 = (labels: Seq[String]) => {
+      if (model.value.getHandleInvalid == "keep")
+        labels.map(label => f(label)).toArray
+      else labels.map(label => f(label)).filterNot(f => f == -1).toArray
+    }
+
+    val f_r = (index: Double) => {
+      if (model.value.labels.length <= index.toInt || index.toInt < 0) {
+        if (model.value.getHandleInvalid == "keep")
+          "__unknow__"
+        else throw new SparkException(s"Unseen index: $index.  To handle unseen labels, " +
+          s"set Param handleInvalid to keep.")
+      }
+      else
+        model.value.labels(index.toInt)
+    }
+
+    sparkSession.udf.register(name + "_array", f2)
+    sparkSession.udf.register(name + "_r", f_r)
+    sparkSession.udf.register(name + "_rarray", (indexs: Seq[Double]) => {
+      indexs.map(index => f_r(index)).filterNot(f => f == "__unknow__").toArray
     })
     UserDefinedFunction(f, DoubleType, Some(Seq(StringType)))
   }

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/mllib/feature/IntTF.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/mllib/feature/IntTF.scala
@@ -1,0 +1,46 @@
+package org.apache.spark.mllib.feature
+
+import java.lang.{Iterable => JavaIterable}
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/**
+  * Created by allwefantasy on 18/1/2018.
+  */
+class IntTF(val numFeatures: Int) extends Serializable {
+
+  def this() = this(1 << 20)
+
+  var binary = false
+
+  def setBinary(value: Boolean): this.type = {
+    binary = value
+    this
+  }
+
+
+  def transform(document: Iterable[Int]): Vector = {
+    val termFrequencies = mutable.HashMap.empty[Int, Double]
+    val setTF = if (binary) (i: Int) => 1.0 else (i: Int) => termFrequencies.getOrElse(i, 0.0) + 1.0
+    document.foreach { term =>
+      val i = term
+      termFrequencies.put(i, setTF(i))
+    }
+    Vectors.sparse(numFeatures, termFrequencies.toSeq)
+  }
+
+  /**
+    * Transforms the input document into a sparse term frequency vector (Java version).
+    */
+  @Since("1.1.0")
+  def transform(document: JavaIterable[Int]): Vector = {
+    transform(document.asScala)
+  }
+
+}
+
+

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/RegisterAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/RegisterAdaptor.scala
@@ -22,7 +22,7 @@ class RegisterAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslA
         case _ =>
       }
     }
-    val alg = AlgMapping.findAlg(format)
+    val alg = MLMapping.findAlg(format)
     val sparkSession = scriptSQLExecListener.sparkSession
     val model = alg.load(sparkSession, path)
     val udf = alg.predict(sparkSession, model, functionName)

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -1,5 +1,6 @@
 package streaming.dsl
 
+import org.apache.spark.sql.SparkSession
 import streaming.dsl.mmlib.SQLAlg
 import streaming.dsl.parser.DSLSQLParser._
 
@@ -28,12 +29,12 @@ class TrainAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdap
       }
     }
     val df = scriptSQLExecListener.sparkSession.table(tableName)
-    val sqlAlg = AlgMapping.findAlg(format)
+    val sqlAlg = MLMapping.findAlg(format)
     sqlAlg.train(df, path, options)
   }
 }
 
-object AlgMapping {
+object MLMapping {
   val mapping = Map[String, String](
     "Word2vec" -> "streaming.dsl.mmlib.algs.SQLWord2Vec",
     "NaiveBayes" -> "streaming.dsl.mmlib.algs.SQLNaiveBayes",
@@ -45,8 +46,16 @@ object AlgMapping {
     "StringIndex" -> "streaming.dsl.mmlib.algs.SQLStringIndex",
     "GBTs" -> "streaming.dsl.mmlib.algs.SQLGBTs",
     "LSVM" -> "streaming.dsl.mmlib.algs.SQLLSVM",
+    "HashTfIdf" -> "streaming.dsl.mmlib.algs.SQLHashTfIdf",
     "TfIdf" -> "streaming.dsl.mmlib.algs.SQLTfIdf"
   )
+
+  def registerMLFunctions(sparkSession: SparkSession) = {
+    //collection operate
+    sparkSession.udf.register("map", (col: String, reg: String) => {
+
+    })
+  }
 
   def findAlg(name: String) = {
     mapping.get(name.capitalize) match {


### PR DESCRIPTION
配合StringIndexer使用。基本原理是，把字符转化成一个数字，让他们形成一一映射，然后文档也表示成一个Int数组，之后再使用IntTF/IDF 得到一个空间向量。比如：

```sql
-- word_table 是一张只有一列的表，每行一个词
train word_table as StringIndex.`/tmp/zhuhl_si_model` where 
inputCol="word" and handleInvalid="skip";
register StringIndex.`/tmp/zhuhl_si_model` as zhuhl_si_predict;

```
到这里，通过zhuhl_si_predict 可以把已给词转化为 数字，通过zhuhl_si_predict_r 可以把数字转化回来。zhuhl_si_predict_array , zhuhl_si_predict_rarray 接受的是数组。

接着

```sql
select zhuhl_si_predict_array(words) as int_word_seq from zhuhl_new_ct
as int_word_seq_table;
```
把文档转换为数字数组。

现在可以使用TFIDF了：

```sql
-- 训练一个tfidf模型
train int_word_seq_table as TfIdf.`/tmp/zhuhl_tfidf_model` where 
inputCol="int_word_seq"
and numFeatures="4" 
and binary="true";

--注册tfidf模型
register TfIdf.`/tmp/zhuhl_tfidf_model` as zhuhl_tfidf_predict;
```

最后得到一个函数，可以把数字数组代表的文档转化为tf/idf为权重的向量了：

```sql
--将文本转化为tf/idf向量
select zhuhl_tfidf_predict(int_word_seq) as features,int_word_seq from int_word_seq_table
as lda_data;
```