### PR TITLE
RowMatrix实现

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -47,7 +47,8 @@ object MLMapping {
     "GBTs" -> "streaming.dsl.mmlib.algs.SQLGBTs",
     "LSVM" -> "streaming.dsl.mmlib.algs.SQLLSVM",
     "HashTfIdf" -> "streaming.dsl.mmlib.algs.SQLHashTfIdf",
-    "TfIdf" -> "streaming.dsl.mmlib.algs.SQLTfIdf"
+    "TfIdf" -> "streaming.dsl.mmlib.algs.SQLTfIdf",
+    "RowMatrix" -> "streaming.dsl.mmlib.algs.SQLRowMatrix"
   )
 
   def registerMLFunctions(sparkSession: SparkSession) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLRowMatrix.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLRowMatrix.scala
@@ -1,0 +1,50 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.mllib.linalg.distributed._
+import org.apache.spark.ml.linalg.{DenseVector, Vector}
+import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import streaming.dsl.mmlib.SQLAlg
+
+/**
+  * Created by allwefantasy on 22/1/2018.
+  */
+class SQLRowMatrix extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val rdd = df.rdd.map { f =>
+      val v = f.getAs(params.getOrElse("inputCol", "features").toString).asInstanceOf[Vector]
+      OldVectors.fromML(v)
+    }.zipWithIndex().map { f =>
+      IndexedRow(f._2, f._1)
+    }
+
+    val randRowMat = new IndexedRowMatrix(rdd).toBlockMatrix().transpose.toCoordinateMatrix().toRowMatrix()
+    var threshhold = 0.0
+    if (params.contains("threshhold")) {
+      threshhold = params.get("threshhold").map(f => f.toDouble).head
+    }
+    val csl = randRowMat.columnSimilarities(threshhold)
+
+    val newdf = df.sparkSession.createDataFrame(csl.entries.map(f => Row(f.i, f.j, f.value)),
+      StructType(Seq(StructField("i", LongType), StructField("j", LongType), StructField("v", DoubleType))))
+    newdf.write.mode(SaveMode.Overwrite).parquet(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    val entries = sparkSession.read.parquet(path)
+    entries.rdd.map { f =>
+      (f.getLong(0), (f.getLong(1), f.getDouble(2)))
+    }.groupByKey().map(f => (f._1, f._2.toMap)).collect().toMap
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[Map[Long, Map[Long, Double]]])
+
+    val f = (i: Long, threshhold: Double) => {
+      model.value(i).filter(f => f._2 > threshhold)
+    }
+    UserDefinedFunction(f, MapType(LongType, DoubleType), Some(Seq(LongType, DoubleType)))
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLRowMatrix.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLRowMatrix.scala
@@ -15,9 +15,8 @@ class SQLRowMatrix extends SQLAlg with Functions {
   override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
     val rdd = df.rdd.map { f =>
       val v = f.getAs(params.getOrElse("inputCol", "features").toString).asInstanceOf[Vector]
-      OldVectors.fromML(v)
-    }.zipWithIndex().map { f =>
-      IndexedRow(f._2, f._1)
+      val label = f.getAs(params.getOrElse("labelCol", "label").toString).asInstanceOf[Long]
+      IndexedRow(label, OldVectors.fromML(v))
     }
 
     val randRowMat = new IndexedRowMatrix(rdd).toBlockMatrix().transpose.toCoordinateMatrix().toRowMatrix()


### PR DESCRIPTION

把每个问题转化lda主题分布，现在需要任意给出一个文档label(严格按照顺序生成的id，可以使用StringIndex生成),可以找到主题分布相似的label集合。

脚本：

```sql
load libsvm.`/spark-2.2.0-bin-hadoop2.7/data/mllib/sample_lda_libsvm_data.txt` as data;
train data as LDA.`/tmp/model` where k="10" and maxIter="10";

register LDA.`/tmp/model` as predict;

select *,zhuhl_lda_predict_doc(features) as features from data
as zhuhl_doclist;

train zhuhl_doclist as RowMatrix.`/tmp/zhuhl_rm_model` where inputCol="features" and labelCol="label";
register RowMatrix.`/tmp/zhuhl_rm_model` as zhuhl_rm_predict;

select zhuhl_rm_predict(label) from data


```