### PR TITLE
支持PageRank

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ## SQL服务化：
 
 1. [SQL Server 服务](https://github.com/allwefantasy/streamingpro/blob/master/docs/sqlservice.md)
-1. [MLSQL示例](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsqlexample.md)
-1. [MLSQL使用手册](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsql.md)
+1. [机器学习MLSQL](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsql.md)
+1. [MLSQL编写Word2Vec脚本](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsqlexample.md)
 
 ## 用配置来编程
 1. [Spark Streaming](https://github.com/allwefantasy/streamingpro/blob/master/docs/sparkstreamingjson.md)

--- a/docs/mlsql.md
+++ b/docs/mlsql.md
@@ -235,7 +235,7 @@ save overwrite result as json.`/tmp/result`;
 ```
 
 
-###FPGrowth
+### FPGrowth
 
 abc.csv:
 
@@ -279,6 +279,48 @@ register LSVM.`/tmp/model` as predict;
 select predict(features)  from data as result;
 save overwrite result as json.`/tmp/result`;
 ```
+
+
+### RowMatrix
+
+当你想计算向量两两相似的时候，RowMatrix提供了一个快速高效的方式。比如LDA计算出了每个文档的向量分布，接着我们需要任意给定一个文章，然后找到
+相似的文章， 则可以使用RowMatrix进行计算。无论如何，当文档到百万，计算量始终都是很大的（没有优化前会有万亿次计算），所以实际使用可以将数据
+先简单分类。之后在类里面再做相似度计算。
+
+另外RowMatrix需要两个字段，一个是向量，一个是数字，数字必须是从0开始递增，用来和矩阵行做对应，方便唯一标记一篇内容。
+如果你的数据不是这样的，比如你的文档的唯一编号是断开的或者是一个字符串，那么你可以使用StringIndex 去生成一个字段作为唯一标记。
+
+```sql
+load libsvm.`/spark-2.2.0-bin-hadoop2.7/data/mllib/sample_lda_libsvm_data.txt` as data;
+train data as LDA.`/tmp/model` where k="10" and maxIter="10";
+
+register LDA.`/tmp/model` as predict;
+
+select *,zhuhl_lda_predict_doc(features) as features from data
+as zhuhl_doclist;
+
+train zhuhl_doclist as RowMatrix.`/tmp/zhuhl_rm_model` where inputCol="features" and labelCol="label";
+register RowMatrix.`/tmp/zhuhl_rm_model` as zhuhl_rm_predict;
+
+select zhuhl_rm_predict(label) from data
+```
+
+### PageRank
+
+PageRank 可以对有关系对的东西进行建模，输入也很简答，只要item-item pair 就行。
+
+```
+load csv.`/spark-2.2.0-bin-hadoop2.7/data/mllib/pagerank_data.txt` as data;
+
+select cast(split(_c0," ")[0] as Long) as edgeSrc,cast(split(_c0," ")[1] as Long) as edgeDst from data
+as new_data;
+
+train new_data as PageRank.`/tmp/pr_model` ;
+register PageRank.`/tmp/pr_model` as zhl_pr_redict;
+
+select zhl_pr_redict(edgeSrc) from new_data;
+```
+
 
 
 

--- a/streamingpro-spark-2.0/pom.xml
+++ b/streamingpro-spark-2.0/pom.xml
@@ -71,12 +71,12 @@
         </profile>
 
         <profile>
-            <id>carbondata-1.1.0</id>
+            <id>carbondata</id>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.carbondata</groupId>
                     <artifactId>carbondata-spark2</artifactId>
-                    <version>1.1.0-incubating-SNAPSHOT</version>
+                    <version>1.2.0</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.spark</groupId>
@@ -194,6 +194,13 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>${scope}</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-graphx_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>${scope}</scope>
         </dependency>

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -48,7 +48,8 @@ object MLMapping {
     "LSVM" -> "streaming.dsl.mmlib.algs.SQLLSVM",
     "HashTfIdf" -> "streaming.dsl.mmlib.algs.SQLHashTfIdf",
     "TfIdf" -> "streaming.dsl.mmlib.algs.SQLTfIdf",
-    "RowMatrix" -> "streaming.dsl.mmlib.algs.SQLRowMatrix"
+    "RowMatrix" -> "streaming.dsl.mmlib.algs.SQLRowMatrix",
+    "PageRank" -> "streaming.dsl.mmlib.algs.SQLPageRank"
   )
 
   def registerMLFunctions(sparkSession: SparkSession) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLPageRank.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLPageRank.scala
@@ -1,0 +1,64 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.graphx.lib.PageRank
+import org.apache.spark.graphx.{Edge, Graph, VertexId}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.{DoubleType, LongType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import streaming.dsl.mmlib.SQLAlg
+
+/**
+  * Created by allwefantasy on 13/1/2018.
+  */
+class SQLPageRank extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val vertexCol = params.getOrElse("vertexCol", "vertextIds").toString
+    val edgeSrcCol = params.getOrElse("edgeSrcCol", "edgeSrc").toString
+    val edgeDstCol = params.getOrElse("edgeDstCol", "edgeDst").toString
+
+    val edges: RDD[Edge[Any]] = df.rdd.map { f =>
+      Edge(f.getAs[Long](edgeSrcCol), f.getAs[Long](edgeDstCol))
+    }
+
+    var vertex: RDD[(VertexId, Any)] = null
+    if (params.contains("vertexCol")) {
+      vertex = df.rdd.map { f =>
+        (f.getAs[Long](vertexCol), "")
+      }
+    } else {
+      vertex = edges.flatMap(f => List(f.srcId, f.dstId)).distinct().map { f =>
+        (f, "")
+      }
+    }
+
+    val graph = Graph(vertex, edges, ())
+    val tol = params.getOrElse("tol", "0.001").toDouble
+    val resetProb = params.getOrElse("resetProb", "0.15").toDouble
+    val pr = PageRank.runUntilConvergence(graph, tol, resetProb)
+    val verticesDf = df.sparkSession.createDataFrame(pr.vertices.map(f => Row(f._1, f._2)),
+      StructType(Seq(StructField("vertextId", LongType), StructField("pagerank", DoubleType))))
+
+    val edgesDf = df.sparkSession.createDataFrame(pr.edges.map(f => Row(f.srcId, f.dstId, f.attr)),
+      StructType(Seq(StructField("srcId", LongType), StructField("dstId", LongType), StructField("weight", DoubleType))))
+
+    verticesDf.write.mode(SaveMode.Overwrite).parquet(path + "/vertices")
+    edgesDf.write.mode(SaveMode.Overwrite).parquet(path + "/edges")
+
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    import sparkSession._
+    val verticesDf = sparkSession.read.parquet(path + "/vertices")
+    verticesDf.collect().map(f => (f.getLong(0), f.getDouble(1))).toMap
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    val model = sparkSession.sparkContext.broadcast(_model.asInstanceOf[Map[Long, Double]])
+
+    val f = (vertexId: Long) => {
+      model.value(vertexId)
+    }
+    UserDefinedFunction(f, DoubleType, Some(Seq(LongType)))
+  }
+}


### PR DESCRIPTION
PageRank 可以对有关系对的东西进行建模，输入也很简答，只要item-item pair 就行。

```
load csv.`/spark-2.2.0-bin-hadoop2.7/data/mllib/pagerank_data.txt` as data;

select cast(split(_c0," ")[0] as Long) as edgeSrc,cast(split(_c0," ")[1] as Long) as edgeDst from data
as new_data;

train new_data as PageRank.`/tmp/pr_model` ;
register PageRank.`/tmp/pr_model` as zhl_pr_redict;

select zhl_pr_redict(edgeSrc) from new_data;