### PR TITLE
完成新的RPC通讯，应用代码可以直接和executor交互

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@
 ## SQL服务 和 机器学习：
 
 1. [SQL服务](https://github.com/allwefantasy/streamingpro/blob/master/docs/sqlservice.md)
-1. [机器学习DSL-MLSQL](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsql.md)
 1. [为什么开发MLSQL](https://github.com/allwefantasy/streamingpro/blob/master/docs/why-develop-mlsql.md)
+1. [MLSQL手册](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsql.md)
+1. [MLSQL编写Word2Vec脚本示例](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsqlexample.md)
+1. [MLSQL结合Tensorflow实现深度学习算法](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsql-tensorflow.md)
 1. [Vector操作函数](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsql-functions.md)
-1. [MLSQL编写Word2Vec脚本](https://github.com/allwefantasy/streamingpro/blob/master/docs/mlsqlexample.md)
 
 ## 用配置来编程
 1. [Spark Streaming](https://github.com/allwefantasy/streamingpro/blob/master/docs/sparkstreamingjson.md)

--- a/docs/mlsql.md
+++ b/docs/mlsql.md
@@ -23,23 +23,6 @@ train data as RandomForest.`/tmp/model` where inputCol="featrues" and maxDepth="
 
 很简单对么？
 
-目前支持的模型有：
-
-```  
-    "Word2vec" -> "streaming.dsl.mmlib.algs.SQLWord2Vec",
-    "NaiveBayes" -> "streaming.dsl.mmlib.algs.SQLNaiveBayes",
-    "RandomForest" -> "streaming.dsl.mmlib.algs.SQLRandomForest",
-    "GBTRegressor" -> "streaming.dsl.mmlib.algs.SQLGBTRegressor",
-    "LDA" -> "streaming.dsl.mmlib.algs.SQLLDA",
-    "KMeans" -> "streaming.dsl.mmlib.algs.SQLKMeans",
-    "FPGrowth" -> "streaming.dsl.mmlib.algs.SQLFPGrowth",
-    "StringIndex" -> "streaming.dsl.mmlib.algs.SQLStringIndex",
-    "GBTs" -> "streaming.dsl.mmlib.algs.SQLGBTs",
-    "LSVM" -> "streaming.dsl.mmlib.algs.SQLLSVM",
-    "HashTfIdf" -> "streaming.dsl.mmlib.algs.SQLHashTfIdf",
-    "TfIdf" -> "streaming.dsl.mmlib.algs.SQLTfIdf"  
-```
-
 如果需要知道算法的输入格式以及算法的参数,可以参看[Spark MLlib](https://spark.apache.org/docs/latest/ml-guide.html)。
 在MLSQL中，输入格式和算法的参数和Spark MLLib保持一致。
 

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/Message.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/Message.scala
@@ -1,0 +1,24 @@
+package org.apache.spark.ps.cluster
+
+import org.apache.spark.rpc.RpcEndpointRef
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.RegisteredExecutor
+
+/**
+  * Created by allwefantasy on 30/1/2018.
+  */
+object Message {
+
+  case class RefreshPSExecutors()
+  case class RegisteredExecutor()
+  case class RegisterExecutorFailed(msg:String)
+
+  case class RegisterPSExecutor(
+                                 executorId: String,
+                                 executorRef: RpcEndpointRef,
+                                 hostname: String,
+                                 cores: Int,
+                                 logUrls: Map[String, String])
+
+  case class TensorFlowModelClean(modelPath: String)
+
+}

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSDriverBackend.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSDriverBackend.scala
@@ -10,10 +10,10 @@ import org.apache.spark.scheduler.cluster.PSDriverEndpoint
 class PSDriverBackend(sc: SparkContext) {
 
   val conf = sc.conf
-  var psDriverBackend: RpcEndpointRef = null
+  var psDriverRpcEndpointRef: RpcEndpointRef = null
 
   def start() = {
-    psDriverBackend = sc.env.rpcEnv.setupEndpoint("PSDriver", new PSDriverEndpoint(sc.env.rpcEnv, sc))
+    psDriverRpcEndpointRef = sc.env.rpcEnv.setupEndpoint("PSDriver", new PSDriverEndpoint(sc))
   }
 
 }

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSDriverBackend.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSDriverBackend.scala
@@ -1,19 +1,39 @@
 package org.apache.spark.ps.cluster
 
 import org.apache.spark.SparkContext
-import org.apache.spark.rpc.{RpcEndpointRef}
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
+import org.apache.spark.rpc.{RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler.cluster.PSDriverEndpoint
+import org.apache.spark.security.CryptoStreamUtils
 
 /**
   * Created by allwefantasy on 30/1/2018.
   */
-class PSDriverBackend(sc: SparkContext) {
+class PSDriverBackend(sc: SparkContext) extends Logging {
 
   val conf = sc.conf
   var psDriverRpcEndpointRef: RpcEndpointRef = null
 
+  def createRpcEnv = {
+    val isDriver = sc.env.executorId == SparkContext.DRIVER_IDENTIFIER
+    val bindAddress = sc.conf.get(DRIVER_BIND_ADDRESS)
+    val advertiseAddress = sc.conf.get(DRIVER_HOST_ADDRESS)
+    val port = sc.conf.getOption("spark.ps.driver.port").getOrElse("7777").toInt
+    val ioEncryptionKey = if (sc.conf.get(IO_ENCRYPTION_ENABLED)) {
+      Some(CryptoStreamUtils.createKey(sc.conf))
+    } else {
+      None
+    }
+    logInfo(s"setup ps driver rpc env: ${bindAddress}:${port} clientMode=${!isDriver}")
+    RpcEnv.create("PSDriverEndpoint", bindAddress, advertiseAddress, port, sc.conf,
+      sc.env.securityManager, clientMode = !isDriver)
+  }
+
   def start() = {
-    psDriverRpcEndpointRef = sc.env.rpcEnv.setupEndpoint("PSDriver", new PSDriverEndpoint(sc))
+    val env = createRpcEnv
+    val pSDriverBackend = new PSDriverEndpoint(sc, env)
+    psDriverRpcEndpointRef = env.setupEndpoint("ps-driver-endpoint", pSDriverBackend)
   }
 
 }

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSDriverBackend.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSDriverBackend.scala
@@ -1,0 +1,21 @@
+package org.apache.spark.ps.cluster
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rpc.{RpcEndpointRef}
+import org.apache.spark.scheduler.cluster.PSDriverEndpoint
+
+/**
+  * Created by allwefantasy on 30/1/2018.
+  */
+class PSDriverBackend(sc: SparkContext) {
+
+  val conf = sc.conf
+  var psDriverBackend: RpcEndpointRef = null
+
+  def start() = {
+    psDriverBackend = sc.env.rpcEnv.setupEndpoint("PSDriver", new PSDriverEndpoint(sc.env.rpcEnv, sc))
+  }
+
+}
+
+

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
@@ -1,0 +1,133 @@
+package org.apache.spark.ps.cluster
+
+import java.util.{Locale, Properties}
+
+import com.codahale.metrics.MetricRegistry
+import org.apache.spark.internal.Logging
+import org.apache.spark.{SecurityManager, SparkContext, SparkEnv}
+import org.apache.spark.metrics.sink.Sink
+import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
+import org.apache.spark.util.ThreadUtils
+import streaming.tensorflow.TFModelLoader
+
+import scala.util.{Failure, Success}
+import java.lang.management.ManagementFactory
+import java.net.URL
+
+import org.apache.spark.deploy.worker.WorkerWatcher
+import org.apache.spark.executor.CoarseGrainedExecutorBackend
+
+import scala.collection.mutable
+import scala.collection.JavaConversions._
+
+/**
+  * Created by allwefantasy on 30/1/2018.
+  */
+class PSExecutorBackend(env: SparkEnv) extends ThreadSafeRpcEndpoint with Logging {
+  val rpcEnv: RpcEnv = env.rpcEnv
+
+  var psDriverUrl: String = null
+  var psExecutorId: String = null
+  var hostname: String = null
+  var cores: Int = 0
+  var appId: String = null
+  val psDriverPort = 7777
+  var psDriverHost: String = null
+  var workerUrl: Option[String] = None
+  val userClassPath = new mutable.ListBuffer[URL]()
+
+  def parseArgs = {
+    val runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+    var argv = runtimeMxBean.getInputArguments().toList
+
+    while (!argv.isEmpty) {
+      argv match {
+        case ("--driver-url") :: value :: tail =>
+          psDriverUrl = value
+          argv = tail
+        case ("--executor-id") :: value :: tail =>
+          psExecutorId = value
+          argv = tail
+        case ("--hostname") :: value :: tail =>
+          hostname = value
+          argv = tail
+        case ("--cores") :: value :: tail =>
+          cores = value.toInt
+          argv = tail
+        case ("--app-id") :: value :: tail =>
+          appId = value
+          argv = tail
+        case ("--worker-url") :: value :: tail =>
+          // Worker url is used in spark standalone mode to enforce fate-sharing with worker
+          workerUrl = Some(value)
+          argv = tail
+        case ("--user-class-path") :: value :: tail =>
+          userClassPath += new URL(value)
+          argv = tail
+        case Nil =>
+        case tail =>
+          System.err.println(s"Unrecognized options: ${tail.mkString(" ")}")
+      }
+    }
+    val Array(host, port) = psDriverUrl.split(":")
+    psDriverHost = host
+    psDriverUrl = psDriverHost + ":" + psDriverPort
+  }
+
+  override def onStart(): Unit = {
+    parseArgs
+    logInfo("Connecting to driver: " + psDriverUrl)
+    rpcEnv.asyncSetupEndpointRefByURI(psDriverUrl).flatMap { ref =>
+      // This is a very fast action so we can use "ThreadUtils.sameThread"
+      val driver = Some(ref)
+      ref.ask[Boolean](Message.RegisterPSExecutor(psExecutorId, self, hostname, cores, extractLogUrls))
+    }(ThreadUtils.sameThread).onComplete {
+      // This is a very fast action so we can use "ThreadUtils.sameThread"
+      case Success(msg) =>
+      // Always receive `true`. Just ignore it
+      case Failure(e) =>
+        logError(s"Cannot register with driver: $psDriverUrl", e)
+    }(ThreadUtils.sameThread)
+  }
+
+  def extractLogUrls: Map[String, String] = {
+    val prefix = "SPARK_LOG_URL_"
+    sys.env.filterKeys(_.startsWith(prefix))
+      .map(e => (e._1.substring(prefix.length).toLowerCase(Locale.ROOT), e._2))
+  }
+
+  override def receive: PartialFunction[Any, Unit] = {
+    case Message.RegisteredExecutor =>
+    case Message.RegisterExecutorFailed =>
+
+  }
+
+
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+    case Message.TensorFlowModelClean(modelPath) => {
+      TFModelLoader.close(modelPath)
+      context.reply(true)
+    }
+  }
+}
+
+class ServiceSink(val property: Properties, val registry: MetricRegistry,
+                  securityMgr: SecurityManager) extends Sink {
+  val env = SparkEnv.get
+
+
+  override def start(): Unit = {
+    if (env.executorId != SparkContext.DRIVER_IDENTIFIER) {
+      val executorBackend = new PSExecutorBackend(env)
+      env.rpcEnv.setupEndpoint("PSExecutor", executorBackend)
+    }
+  }
+
+  override def stop(): Unit = {
+
+  }
+
+  override def report(): Unit = {
+
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
@@ -42,7 +42,7 @@ class PSExecutorBackend(env: SparkEnv) extends ThreadSafeRpcEndpoint with Loggin
     val advertiseAddress = ""
     val port = env.conf.getOption("spark.ps.executor.port").getOrElse("0").toInt
     val ioEncryptionKey = if (env.conf.get(IO_ENCRYPTION_ENABLED)) {
-      Some(CryptoStreamUtils.createKey(sc.conf))
+      Some(CryptoStreamUtils.createKey(env.conf))
     } else {
       None
     }
@@ -124,14 +124,15 @@ class PSExecutorBackend(env: SparkEnv) extends ThreadSafeRpcEndpoint with Loggin
 
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
     case Message.TensorFlowModelClean(modelPath) => {
+      logInfo("ps executor get message: Message.TensorFlowModelClean")
       TFModelLoader.close(modelPath)
       context.reply(true)
     }
   }
 }
 
-class ServiceSink(val property: Properties, val registry: MetricRegistry,
-                  securityMgr: SecurityManager) extends Sink {
+class PSServiceSink(val property: Properties, val registry: MetricRegistry,
+                    securityMgr: SecurityManager) extends Sink {
   val env = SparkEnv.get
 
 

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
@@ -1,97 +1,20 @@
 package org.apache.spark.ps.cluster
 
-import java.util.{Locale, Properties}
+import java.util.{Locale}
 
-import com.codahale.metrics.MetricRegistry
 import org.apache.spark.internal.Logging
-import org.apache.spark.{SecurityManager, SparkContext, SparkEnv}
-import org.apache.spark.metrics.sink.Sink
+import org.apache.spark.{SparkEnv}
 import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.util.ThreadUtils
 import streaming.tensorflow.TFModelLoader
 
 import scala.util.{Failure, Success}
-import java.lang.management.ManagementFactory
-import java.net.URL
 
-import org.apache.spark.internal.config._
-import org.apache.spark.security.CryptoStreamUtils
-
-import scala.collection.mutable
-import scala.collection.JavaConversions._
 
 /**
   * Created by allwefantasy on 30/1/2018.
   */
-class PSExecutorBackend(env: SparkEnv) extends ThreadSafeRpcEndpoint with Logging {
-
-
-  var psDriverUrl: String = null
-  var psExecutorId: String = null
-  var hostname: String = null
-  var cores: Int = 0
-  var appId: String = null
-  val psDriverPort = 7777
-  var psDriverHost: String = null
-  var workerUrl: Option[String] = None
-  val userClassPath = new mutable.ListBuffer[URL]()
-
-  def createRpcEnv = {
-    val isDriver = env.executorId == SparkContext.DRIVER_IDENTIFIER
-    val bindAddress = hostname
-    val advertiseAddress = ""
-    val port = env.conf.getOption("spark.ps.executor.port").getOrElse("0").toInt
-    val ioEncryptionKey = if (env.conf.get(IO_ENCRYPTION_ENABLED)) {
-      Some(CryptoStreamUtils.createKey(env.conf))
-    } else {
-      None
-    }
-    RpcEnv.create("PSExecutorBackend", bindAddress, advertiseAddress, port, env.conf,
-      env.securityManager, clientMode = !isDriver)
-  }
-
-
-  def parseArgs = {
-    val runtimeMxBean = ManagementFactory.getRuntimeMXBean();
-    var argv = runtimeMxBean.getInputArguments().toList
-
-    while (!argv.isEmpty) {
-      argv match {
-        case ("--driver-url") :: value :: tail =>
-          psDriverUrl = value
-          argv = tail
-        case ("--executor-id") :: value :: tail =>
-          psExecutorId = value
-          argv = tail
-        case ("--hostname") :: value :: tail =>
-          hostname = value
-          argv = tail
-        case ("--cores") :: value :: tail =>
-          cores = value.toInt
-          argv = tail
-        case ("--app-id") :: value :: tail =>
-          appId = value
-          argv = tail
-        case ("--worker-url") :: value :: tail =>
-          // Worker url is used in spark standalone mode to enforce fate-sharing with worker
-          workerUrl = Some(value)
-          argv = tail
-        case ("--user-class-path") :: value :: tail =>
-          userClassPath += new URL(value)
-          argv = tail
-        case Nil =>
-        case tail =>
-          System.err.println(s"Unrecognized options: ${tail.mkString(" ")}")
-      }
-    }
-    val Array(host, port) = psDriverUrl.split(":")
-    psDriverHost = host
-    psDriverUrl = psDriverHost + ":" + psDriverPort
-  }
-
-  parseArgs
-
-  override val rpcEnv: RpcEnv = createRpcEnv
+class PSExecutorBackend(env: SparkEnv, override val rpcEnv: RpcEnv, psDriverUrl: String, psExecutorId: String, hostname: String, cores: Int) extends ThreadSafeRpcEndpoint with Logging {
 
   override def onStart(): Unit = {
 
@@ -103,6 +26,7 @@ class PSExecutorBackend(env: SparkEnv) extends ThreadSafeRpcEndpoint with Loggin
     }(ThreadUtils.sameThread).onComplete {
       // This is a very fast action so we can use "ThreadUtils.sameThread"
       case Success(msg) =>
+        logInfo(s"${psExecutorId}@${hostname} register with driver: $psDriverUrl success")
       // Always receive `true`. Just ignore it
       case Failure(e) =>
         logError(s"Cannot register with driver: $psDriverUrl", e)
@@ -131,23 +55,4 @@ class PSExecutorBackend(env: SparkEnv) extends ThreadSafeRpcEndpoint with Loggin
   }
 }
 
-class PSServiceSink(val property: Properties, val registry: MetricRegistry,
-                    securityMgr: SecurityManager) extends Sink {
-  val env = SparkEnv.get
 
-
-  override def start(): Unit = {
-    if (env.executorId != SparkContext.DRIVER_IDENTIFIER) {
-      val executorBackend = new PSExecutorBackend(env)
-      env.rpcEnv.setupEndpoint("PSExecutor", executorBackend)
-    }
-  }
-
-  override def stop(): Unit = {
-
-  }
-
-  override def report(): Unit = {
-
-  }
-}

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSServiceSink.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/cluster/PSServiceSink.scala
@@ -1,0 +1,127 @@
+package org.apache.spark.ps.cluster
+
+import java.lang.management.ManagementFactory
+import java.net.URL
+import java.util.Properties
+
+import com.codahale.metrics.MetricRegistry
+import org.apache.spark.internal.Logging
+import org.apache.spark.{SecurityManager, SparkContext, SparkEnv}
+import org.apache.spark.internal.config._
+import org.apache.spark.metrics.sink.Sink
+import org.apache.spark.rpc.RpcEnv
+import org.apache.spark.security.CryptoStreamUtils
+
+import scala.collection.mutable
+
+/**
+  * Created by allwefantasy on 2/2/2018.
+  */
+class PSServiceSink(val property: Properties, val registry: MetricRegistry,
+                    securityMgr: SecurityManager) extends Sink with Logging {
+  def env = SparkEnv.get
+
+  var psDriverUrl: String = null
+  var psExecutorId: String = null
+  var hostname: String = null
+  var cores: Int = 0
+  var appId: String = null
+  val psDriverPort = 7777
+  var psDriverHost: String = null
+  var workerUrl: Option[String] = None
+  val userClassPath = new mutable.ListBuffer[URL]()
+
+  def parseArgs = {
+    //val runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+    //var argv = runtimeMxBean.getInputArguments.toList
+    var argv = System.getProperty("sun.java.command").split("\\s+").toList
+
+    var count = 0
+    var first = 0
+    argv.foreach { f =>
+      if (f.startsWith("--") && first == 0) {
+        first = count
+      }
+      count += 1
+    }
+    argv = argv.drop(first)
+
+    while (!argv.isEmpty) {
+      argv match {
+        case ("--driver-url") :: value :: tail =>
+          psDriverUrl = value
+          argv = tail
+        case ("--executor-id") :: value :: tail =>
+          psExecutorId = value
+          argv = tail
+        case ("--hostname") :: value :: tail =>
+          hostname = value
+          argv = tail
+        case ("--cores") :: value :: tail =>
+          cores = value.toInt
+          argv = tail
+        case ("--app-id") :: value :: tail =>
+          appId = value
+          argv = tail
+        case ("--worker-url") :: value :: tail =>
+          // Worker url is used in spark standalone mode to enforce fate-sharing with worker
+          workerUrl = Some(value)
+          argv = tail
+        case ("--user-class-path") :: value :: tail =>
+          userClassPath += new URL(value)
+          argv = tail
+        case Nil =>
+        case tail =>
+          System.err.println(s"Unrecognized options: ${tail.mkString(" ")}")
+      }
+    }
+    if (psDriverUrl.contains("@")) {
+      psDriverUrl = psDriverUrl.split("@").last
+    }
+    val Array(host, port) = psDriverUrl.split(":")
+    psDriverHost = host
+    psDriverUrl = "spark://ps-driver-endpoint@" + psDriverHost + ":" + psDriverPort
+  }
+
+  parseArgs
+
+  def createRpcEnv = {
+    val isDriver = env.executorId == SparkContext.DRIVER_IDENTIFIER
+    val bindAddress = hostname
+    val advertiseAddress = ""
+    val port = env.conf.getOption("spark.ps.executor.port").getOrElse("0").toInt
+    val ioEncryptionKey = if (env.conf.get(IO_ENCRYPTION_ENABLED)) {
+      Some(CryptoStreamUtils.createKey(env.conf))
+    } else {
+      None
+    }
+    //logInfo(s"setup ps driver rpc env: ${bindAddress}:${port} clientMode=${!isDriver}")
+    RpcEnv.create("PSExecutorBackend", bindAddress, advertiseAddress, port, env.conf,
+      env.securityManager, clientMode = !isDriver)
+  }
+
+  override def start(): Unit = {
+
+    new Thread(new Runnable {
+      override def run(): Unit = {
+        logInfo(s"delay PSExecutorBackend 3s")
+        Thread.sleep(3000)
+        logInfo(s"start PSExecutor;env:${env}")
+        if (env.executorId != SparkContext.DRIVER_IDENTIFIER) {
+          val rpcEnv = createRpcEnv
+          val pSExecutorBackend = new PSExecutorBackend(env, rpcEnv, psDriverUrl, psExecutorId, hostname, cores)
+          rpcEnv.setupEndpoint("ps-executor-endpoint", pSExecutorBackend)
+        }
+      }
+    }).start()
+
+  }
+
+  override def stop(): Unit = {
+
+  }
+
+  override def report(): Unit = {
+
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/local/LocalPSSchedulerBackend.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/ps/local/LocalPSSchedulerBackend.scala
@@ -1,0 +1,91 @@
+package org.apache.spark.ps.local
+
+import java.io.File
+import java.net.URL
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv}
+import org.apache.spark.internal.Logging
+import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
+import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
+import org.apache.spark.scheduler._
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.StopExecutor
+import streaming.tensorflow.TFModelLoader
+
+private case class TensorFlowModelClean(modelPath: String)
+
+
+/**
+  * Calls to [[LocalPSSchedulerBackend]] are all serialized through LocalEndpoint. Using an
+  * RpcEndpoint makes the calls on [[LocalPSSchedulerBackend]] asynchronous, which is necessary
+  * to prevent deadlock between [[LocalPSSchedulerBackend]] and the [[TaskSchedulerImpl]].
+  */
+class LocalPSEndpoint(override val rpcEnv: RpcEnv,
+                      userClassPath: Seq[URL]
+
+                   )
+  extends ThreadSafeRpcEndpoint with Logging {
+
+  val localExecutorId = SparkContext.DRIVER_IDENTIFIER
+  val localExecutorHostname = "localhost"
+
+  override def receive: PartialFunction[Any, Unit] = {
+    case _ =>
+
+  }
+
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+    case TensorFlowModelClean(modelPath) =>
+      logInfo("close tensorflow model: " + modelPath)
+      TFModelLoader.close(modelPath)
+      context.reply(true)
+  }
+}
+
+
+class LocalPSSchedulerBackend(sparkContext: SparkContext)
+  extends Logging {
+
+  private val appId = "local-ps-" + System.currentTimeMillis
+  private var localEndpoint: RpcEndpointRef = null
+  private val userClassPath = getUserClasspath(sparkContext.getConf)
+  private val launcherBackend = new LauncherBackend() {
+    override def onStopRequest(): Unit = stop(SparkAppHandle.State.KILLED)
+  }
+
+  /**
+    * Returns a list of URLs representing the user classpath.
+    *
+    * @param conf Spark configuration.
+    */
+  def getUserClasspath(conf: SparkConf): Seq[URL] = {
+    val userClassPathStr = conf.getOption("spark.executor.extraClassPath")
+    userClassPathStr.map(_.split(File.pathSeparator)).toSeq.flatten.map(new File(_).toURI.toURL)
+  }
+
+  launcherBackend.connect()
+
+  def start() {
+    val rpcEnv = SparkEnv.get.rpcEnv
+    val executorEndpoint = new LocalPSEndpoint(rpcEnv, userClassPath)
+    localEndpoint = rpcEnv.setupEndpoint("PSLocalSchedulerBackend", executorEndpoint)
+    launcherBackend.setAppId(appId)
+    launcherBackend.setState(SparkAppHandle.State.RUNNING)
+  }
+
+  def stop() {
+    stop(SparkAppHandle.State.FINISHED)
+  }
+
+  def cleanTensorFlowModel(modelPath: String) = {
+    localEndpoint.askSync[Boolean](TensorFlowModelClean(modelPath))
+  }
+
+  private def stop(finalState: SparkAppHandle.State): Unit = {
+    localEndpoint.ask(StopExecutor)
+    try {
+      launcherBackend.setState(finalState)
+    } finally {
+      launcherBackend.close()
+    }
+  }
+
+}

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/scheduler/cluster/PSDriverEndpoint.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/scheduler/cluster/PSDriverEndpoint.scala
@@ -47,6 +47,7 @@ class PSDriverEndpoint(sc: SparkContext)
       val ks = sparkExecutorDataMap.keySet
       executorDataMap.foreach { ed =>
         if (ks.contains(ed._1)) {
+          logInfo("ps driver send message: Message.TensorFlowModelClean")
           ed._2.executorEndpoint.askSync[Boolean](Message.TensorFlowModelClean(modelPath))
         }
       }

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/scheduler/cluster/PSDriverEndpoint.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/scheduler/cluster/PSDriverEndpoint.scala
@@ -1,0 +1,76 @@
+package org.apache.spark.scheduler.cluster
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.SparkContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.ps.cluster.Message
+import org.apache.spark.rpc.{RpcAddress, RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
+import org.apache.spark.util.{ThreadUtils, Utils}
+
+import scala.collection.mutable.HashMap
+
+/**
+  * Created by allwefantasy on 31/1/2018.
+  */
+class PSDriverEndpoint(override val rpcEnv: RpcEnv, sc: SparkContext)
+  extends ThreadSafeRpcEndpoint with Logging {
+  protected val addressToExecutorId = new HashMap[RpcAddress, String]
+  private val executorDataMap = new HashMap[String, ExecutorData]()
+  private var sparkExecutorDataMap = new HashMap[String, ExecutorData]()
+  private val refreshThread =
+    ThreadUtils.newDaemonSingleThreadScheduledExecutor("ps-driver-refresh-thread")
+
+
+  override def onStart() {
+    // Periodically revive offers to allow delay scheduling to work
+    val refreshInterval = 1000
+
+    refreshThread.scheduleAtFixedRate(new Runnable {
+      override def run(): Unit = Utils.tryLogNonFatalError {
+        Option(self).foreach(_.send(Message.RefreshPSExecutors))
+      }
+    }, 0, refreshInterval, TimeUnit.MILLISECONDS)
+  }
+
+  override def receive: PartialFunction[Any, Unit] = {
+    case Message.RefreshPSExecutors =>
+      //.executorDataMap
+      val cgsb = sc.schedulerBackend.asInstanceOf[CoarseGrainedSchedulerBackend]
+      val field = CoarseGrainedSchedulerBackend.getClass.getDeclaredField("executorDataMap")
+      field.setAccessible(true)
+      sparkExecutorDataMap = field.get(cgsb).asInstanceOf[HashMap[String, ExecutorData]]
+
+    case Message.TensorFlowModelClean(modelPath) =>
+      val ks = sparkExecutorDataMap.keySet
+      executorDataMap.foreach { ed =>
+        if (ks.contains(ed._1)) {
+          ed._2.executorEndpoint.askSync[Boolean](Message.TensorFlowModelClean(modelPath))
+        }
+      }
+  }
+
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+    case Message.RegisterPSExecutor(executorId, executorRef, hostname, cores, logUrls) =>
+      if (executorDataMap.contains(executorId)) {
+        executorRef.send(Message.RegisterExecutorFailed("Duplicate executor ID: " + executorId))
+        context.reply(true)
+      } else {
+        val executorAddress = if (executorRef.address != null) {
+          executorRef.address
+        } else {
+          context.senderAddress
+        }
+        logInfo(s"Registered ps-executor $executorRef ($executorAddress) with ID $executorId")
+        addressToExecutorId(executorAddress) = executorId
+
+        val data = new ExecutorData(executorRef, executorRef.address, hostname,
+          cores, cores, logUrls)
+        executorRef.send(Message.RegisteredExecutor)
+        // Note: some tests expect the reply to come after we put the executor in the map
+        context.reply(true)
+      }
+
+
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/streaming/core/LoalSparkServiceApp.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/core/LoalSparkServiceApp.scala
@@ -14,11 +14,12 @@ object LocalSparkServiceApp {
       "-streaming.job.file.path", "classpath:///test/empty.json",
       "-streaming.enableHiveSupport", "true",
       "-streaming.spark.service", "true",
-      "-streaming.job.cancel","true",
+      "-streaming.job.cancel", "true",
+      "-streaming.ps.enable", "true",
       "-streaming.enableCarbonDataSupport", "false",
       "-streaming.carbondata.store", "/data/carbon/store",
       "-streaming.carbondata.meta", "/data/carbon/meta",
-      "-spark.sql.hive.thriftServer.singleSession","true",
+      "-spark.sql.hive.thriftServer.singleSession", "true",
       "-streaming.driver.port", "9003"
       //"-streaming.sql.out.path","file:///tmp/test/pdate=20160809"
 

--- a/streamingpro-spark-2.0/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -52,7 +52,8 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
         master == "local" || master.startsWith("local[")
       }
       if (!isLocalMaster(conf)) {
-        conf.set("worker.sink.pservice.class", "org.apache.spark.ps.cluster.PSServiceSink")
+        logger.info("register worker.sink.pservice.class with org.apache.spark.ps.cluster.PSServiceSink")
+        conf.set("spark.metrics.conf.executor.sink.pservice.class", "org.apache.spark.ps.cluster.PSServiceSink")
       }
     }
 
@@ -91,6 +92,7 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
         localSchedulerBackend = new LocalPSSchedulerBackend(ss.sparkContext)
         localSchedulerBackend.start()
       } else {
+        logger.info("start PSDriverBackend")
         psDriverBackend = new PSDriverBackend(ss.sparkContext)
         psDriverBackend.start()
       }

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLPython.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLPython.scala
@@ -1,0 +1,8 @@
+package streaming.dsl.mmlib.algs
+
+/**
+  * Created by allwefantasy on 1/2/2018.
+  */
+class SQLPython {
+
+}

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLTensorFlow.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLTensorFlow.scala
@@ -130,6 +130,9 @@ class SQLTensorFlow extends SQLAlg with Functions {
       Vectors.dense(res.map(f => f.toDouble))
 
     }
+    //    sparkSession.udf.register("release_tensorflow_memory", (modelPath: String) => {
+    //      TFModelLoader.close(modelPath)
+    //    })
     UserDefinedFunction(f, VectorType, Some(Seq(VectorType, StringType, StringType, IntegerType)))
   }
 }

--- a/streamingpro-spark-2.0/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/rest/RestController.scala
@@ -8,6 +8,7 @@ import net.csdn.common.path.Url
 import net.csdn.modules.http.{ApplicationController, ViewType}
 import net.csdn.modules.http.RestRequest.Method._
 import net.csdn.modules.transport.HttpTransportService
+import org.apache.spark.ps.cluster.Message
 import org.apache.spark.sql.{DataFrameWriter, Row, SaveMode}
 import streaming.common.JarUtil
 import streaming.core.{AsyncJobRunner, DownloadRunner, JobCanceller}
@@ -207,6 +208,13 @@ class RestController extends ApplicationController {
   def check = {
     val sparkSession = runtime.asInstanceOf[SparkRuntime].sparkSession
     render(sparkSession.table(param("name")))
+  }
+
+  @At(path = Array("/test"), types = Array(GET, POST))
+  def test = {
+    val psDriverBackend = runtime.asInstanceOf[SparkRuntime].psDriverBackend
+    psDriverBackend.psDriverRpcEndpointRef.send(Message.TensorFlowModelClean)
+    render("{}")
   }
 
   def runtime = PlatformManager.getRuntime

--- a/streamingpro-spark-2.0/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/rest/RestController.scala
@@ -213,7 +213,7 @@ class RestController extends ApplicationController {
   @At(path = Array("/test"), types = Array(GET, POST))
   def test = {
     val psDriverBackend = runtime.asInstanceOf[SparkRuntime].psDriverBackend
-    psDriverBackend.psDriverRpcEndpointRef.send(Message.TensorFlowModelClean)
+    psDriverBackend.psDriverRpcEndpointRef.send(Message.TensorFlowModelClean("/tmp/ok"))
     render("{}")
   }
 

--- a/streamingpro-spark-2.0/src/test/java/streaming/core/Test.scala
+++ b/streamingpro-spark-2.0/src/test/java/streaming/core/Test.scala
@@ -1,27 +1,78 @@
 package streaming.core
 
+import java.net.URL
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.mutable
 
 /**
   * Created by allwefantasy on 28/3/2017.
   */
 object Test {
+  var psDriverUrl: String = null
+  var psExecutorId: String = null
+  var hostname: String = null
+  var cores: Int = 0
+  var appId: String = null
+  val psDriverPort = 7777
+  var psDriverHost: String = null
+  var workerUrl: Option[String] = None
+  val userClassPath = new mutable.ListBuffer[URL]()
+
+  def parseArgs = {
+    //val runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+    //var argv = runtimeMxBean.getInputArguments.toList
+    var argv = "org.apache.spark.executor.CoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@192.168.219.49:64455 --executor-id 0 --hostname 192.168.219.49 --cores 1 --app-id app-20180202171521-0037 --worker-url spark://Worker@192.168.219.49:60980".split("\\s+").toList
+    var count = 0
+    var first = 0
+    argv.foreach { f =>
+      if (f.startsWith("--") && first == 0) {
+        first = count
+      }
+      count += 1
+    }
+    argv = argv.drop(first)
+
+    while (!argv.isEmpty) {
+      argv match {
+        case ("--driver-url") :: value :: tail =>
+          psDriverUrl = value
+          argv = tail
+        case ("--executor-id") :: value :: tail =>
+          psExecutorId = value
+          argv = tail
+        case ("--hostname") :: value :: tail =>
+          hostname = value
+          argv = tail
+        case ("--cores") :: value :: tail =>
+          cores = value.toInt
+          argv = tail
+        case ("--app-id") :: value :: tail =>
+          appId = value
+          argv = tail
+        case ("--worker-url") :: value :: tail =>
+          // Worker url is used in spark standalone mode to enforce fate-sharing with worker
+          workerUrl = Some(value)
+          argv = tail
+        case ("--user-class-path") :: value :: tail =>
+          userClassPath += new URL(value)
+          argv = tail
+        case Nil =>
+        case tail =>
+          System.err.println(s"Unrecognized options: ${tail.mkString(" ")}")
+      }
+    }
+    val Array(host, port) = psDriverUrl.split(":")
+    psDriverHost = host
+    psDriverUrl = psDriverHost + ":" + psDriverPort
+  }
 
   def main(args: Array[String]): Unit = {
-    val conf = new SparkConf().setAppName("BatchSparkSQL")
-    conf.setMaster("local[2]")
-    val sc = SparkSession.builder().config(conf).getOrCreate()
-
-    val words = sc.sparkContext.textFile("file:///Users/allwefantasy/Downloads/results-3.csv")
-
-    val input = words.mapPartitions { f =>
-      val jack = new Jack()
-      f.map(k => jack.echo(k))
-    }
-    input.count()
-    sc.stop()
+    parseArgs
+    println(psDriverUrl)
 
   }
 }

--- a/streamingpro-tensorflow/src/main/java/streaming/tensorflow/TFModelLoader.scala
+++ b/streamingpro-tensorflow/src/main/java/streaming/tensorflow/TFModelLoader.scala
@@ -13,7 +13,7 @@ object TFModelLoader {
   def load(modelPath: String) = synchronized {
     var count = 0
     val count_upper_bound = 10
-    //if take too much time to load 50s ,then maybe just return null
+    //if take too much time to load eg. 50s,then maybe just return null
     if (map.containsKey(modelPath) || loading_status_map.containsKey(modelPath)) {
       while (loading_status_map.containsKey(modelPath) && count < count_upper_bound) {
         Thread.sleep(5000)
@@ -32,6 +32,12 @@ object TFModelLoader {
     }
   }
 
+  def close(modelPath: String) = {
+    if (map.containsKey(modelPath)) {
+      val sm = map.remove(modelPath)
+      sm.close()
+    }
+  }
 
 }
 


### PR DESCRIPTION
可以分别针对driver 和executor 开发代码实现PRC通讯，绕过只能通过task进行交互的限制。
方便实现PS结构以及做数据清理。