### PR TITLE
tensorflow 支持validateTable参数的设置

### DIFF
--- a/streamingpro-spark-2.0/src/main/resources-local/python/mlsql.py
+++ b/streamingpro-spark-2.0/src/main/resources-local/python/mlsql.py
@@ -59,6 +59,14 @@ if "internalSystemParam" in _params:
 if "systemParam" in _params:
     systemParam = _params["systemParam"]
 
+validate_table_filename = os.path.join(os.getcwd(), "validate_table.pickle")
+raw_validate_data = load(validate_table_filename)
+validate_data = []
+for item in raw_validate_data:
+    with io.BytesIO(item) as f:
+        msg = pickle.load(f)
+        validate_data.append(msg)
+
 
 def read_data():
     # Update params
@@ -245,6 +253,10 @@ def _get_param(p, name, default_value):
 
 def get_param(p, name, default_value):
     return _get_param(p, name, default_value)
+
+
+def get_validate_data():
+    return validate_data
 
 
 def sklearn_batch_data(fn):

--- a/streamingpro-spark-2.0/src/main/resources-local/python/mlsql_tf_FCClassify.py
+++ b/streamingpro-spark-2.0/src/main/resources-local/python/mlsql_tf_FCClassify.py
@@ -19,6 +19,7 @@ layer_group = [int(i) for i in mlsql.get_param(fitParams, "layerGroup", "300").s
 
 batch_size = int(mlsql.get_param(fitParams, "batchSize", 32))
 epochs = int(mlsql.get_param(fitParams, "epochs", 1))
+print_interval = int(mlsql.get_param(fitParams, "printInterval", 1))
 
 input_col = mlsql.get_param(fitParams, "inputCol", "features")
 label_col = mlsql.get_param(fitParams, "labelCol", "label")
@@ -67,6 +68,10 @@ summ = tf.summary.merge_all()
 
 sess.run(tf.global_variables_initializer())
 
+test_items = mlsql.get_validate_data()
+TEST_X = [item[input_col].toArray() for item in test_items]
+TEST_Y = [item[label_col].toArray() for item in test_items]
+
 for ep in range(epochs):
     for items in rd(max_records=batch_size):
         X = [item[input_col].toArray() for item in items]
@@ -78,11 +83,16 @@ for ep in range(epochs):
                              feed_dict={input_x: X, input_y: Y})
             [train_accuracy, s, loss] = sess.run([accurate, summ, xent],
                                                  feed_dict={input_x: X, input_y: Y})
-            print('train_accuracy %g, loss: %g, global step: %d, ep:%d' % (
-                train_accuracy,
-                loss,
-                gs, ep))
-        sys.stdout.flush()
+            [test_accuracy, test_s, test_lost] = sess.run([accurate, summ, xent],
+                                                          feed_dict={input_x: TEST_X, input_y: TEST_Y})
+            if gs % print_interval == 0:
+                print('train_accuracy %g,test_accuracy %g, loss: %g, test_lost: %g,global step: %d, ep:%d' % (
+                    train_accuracy,
+                    test_accuracy,
+                    loss,
+                    test_lost,
+                    gs, ep))
+            sys.stdout.flush()
 
-mlsql_model.save_model(tempModelLocalPath, sess, input_x, _logits, True)
-sess.close()
+    mlsql_model.save_model(tempModelLocalPath, sess, input_x, _logits, True)
+    sess.close()


### PR DESCRIPTION
```sql
-- tensorflow
load libsvm.`/Users/allwefantasy/Softwares/spark-2.2.0-bin-hadoop2.7/data/mllib/sample_libsvm_data.txt` as data;

select onehot(label,2) as label,features from data
as newdata;


select * from newdata limit 2 
as data1;


train newdata as TensorFlow.`/tmp/model` 
where `kafkaParam.bootstrap.servers`="127.0.0.1:9092"
and   `kafkaParam.topic`="test"
and   `kafkaParam.group_id`="g_test-1"
and   `kafkaParam.reuse`="false"
and   `fitParam.0.layerGroup`="300,100"
and   `fitParam.0.epochs`="1"
and   `fitParam.0.batchSize`="32"
and   `fitParam.0.featureSize`="692"
and   `fitParam.0.labelSize`="2"
and   `fitParam.0.alg`="FCClassify"
and  `validateTable`="data1"
and   `systemParam.pythonPath`="python";
```

通过配置validateTable后，可以通过mlsql.get_validate_data() 方法获取测试数据集。