### PR TITLE
允许用户自定义save format

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
@@ -88,11 +88,13 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
       case "kafka8" | "kafka9" =>
         writer.option("topics", final_path).format("com.hortonworks.spark.sql.kafka08").save()
       case "hbase" =>
-        writer.option("outputTableName", final_path).format("org.apache.spark.sql.execution.datasources.hbase").save()
+        writer.option("outputTableName", final_path).format(
+          option.getOrElse("implClass", "org.apache.spark.sql.execution.datasources.hbase")).save()
       case "redis" =>
-        writer.option("outputTableName", final_path).format("org.apache.spark.sql.execution.datasources.redis").save()
+        writer.option("outputTableName", final_path).format(
+          option.getOrElse("implClass", "org.apache.spark.sql.execution.datasources.redis")).save()
       case _ =>
-        writer.save(final_path)
+        writer.format(option.getOrElse("implClass", format)).save(final_path)
     }
   }
 }


### PR DESCRIPTION
```
set yesterdayM=`date -v-1d +%Y-%m-%d`;

select  array(1,2,3)  as t as tm;

save overwrite tm as hbase2.`/tmp/new_vs_uc_touchpoint_di/hp_stat_date=${yesterdayM}` 
options implClass="org.apache.spark.sql.execution.datasources.hbase2";

```

用户只需要给自己定义一个名字，然后通过options选项指定 implClass即可。当然，启动时需要带上你自己实现的jar包。