### PR TITLE
[add] load语法支持load非用户根路径的文件

### DIFF
--- a/streamingpro-spark-2.0/pom.xml
+++ b/streamingpro-spark-2.0/pom.xml
@@ -87,7 +87,7 @@
         </profile>
 
         <profile>
-            <id>dsl-legacy</id>
+            <id>dsl</id>
             <dependencies>
                 <dependency>
                     <groupId>streaming.king</groupId>
@@ -98,7 +98,7 @@
         </profile>
 
         <profile>
-            <id>dsl</id>
+            <id>dsl-legacy</id>
             <dependencies>
                 <dependency>
                     <groupId>streaming.king</groupId>

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/LoadAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/LoadAdaptor.scala
@@ -55,7 +55,8 @@ class LoadAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
       case "crawlersql" =>
         table = reader.option("path",cleanStr(path)).format("org.apache.spark.sql.execution.datasources.crawlersql").load()
       case _ =>
-        table = reader.format(format).load(withPathPrefix(scriptSQLExecListener.pathPrefix, cleanStr(path)))
+        val owner = option.get("owner")
+        table = reader.format(format).load(withPathPrefix(scriptSQLExecListener.pathPrefix(owner), cleanStr(path)))
     }
     table.createOrReplaceTempView(tableName)
   }

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/RegisterAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/RegisterAdaptor.scala
@@ -10,6 +10,7 @@ class RegisterAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslA
     var functionName = ""
     var format = ""
     var path = ""
+//    val owner = option.get("owner")
     (0 to ctx.getChildCount() - 1).foreach { tokenIndex =>
 
       ctx.getChild(tokenIndex) match {
@@ -18,7 +19,7 @@ class RegisterAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslA
         case s: FormatContext =>
           format = s.getText
         case s: PathContext =>
-          path = withPathPrefix(scriptSQLExecListener.pathPrefix, cleanStr(s.getText))
+          path = withPathPrefix(scriptSQLExecListener.pathPrefix(None), cleanStr(s.getText))
         case _ =>
       }
     }

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/SaveAdaptor.scala
@@ -18,6 +18,8 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
     var tableName = ""
     var partitionByCol = Array[String]()
 
+    val owner = option.get("owner")
+
     (0 to ctx.getChildCount() - 1).foreach { tokenIndex =>
       ctx.getChild(tokenIndex) match {
         case s: FormatContext =>
@@ -34,7 +36,7 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
             case "hive" | "kafka8" | "kafka9" | "hbase" | "redis" | "es" =>
               final_path = cleanStr(s.getText)
             case _ =>
-              final_path = withPathPrefix(scriptSQLExecListener.pathPrefix, cleanStr(s.getText))
+              final_path = withPathPrefix(scriptSQLExecListener.pathPrefix(owner), cleanStr(s.getText))
           }
 
           final_path = TemplateMerge.merge(final_path, scriptSQLExecListener.env().toMap)

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -13,6 +13,7 @@ class TrainAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdap
     var format = ""
     var path = ""
     var options = Map[String, String]()
+    val owner = options.get("owner")
     (0 to ctx.getChildCount() - 1).foreach { tokenIndex =>
       ctx.getChild(tokenIndex) match {
         case s: TableNameContext =>
@@ -20,7 +21,7 @@ class TrainAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdap
         case s: FormatContext =>
           format = s.getText
         case s: PathContext =>
-          path = withPathPrefix(scriptSQLExecListener.pathPrefix, cleanStr(s.getText))
+          path = withPathPrefix(scriptSQLExecListener.pathPrefix(owner), cleanStr(s.getText))
         case s: ExpressionContext =>
           options += (cleanStr(s.identifier().getText) -> cleanStr(s.STRING().getText))
         case s: BooleanExpressionContext =>


### PR DESCRIPTION
example

```shell
curl -X POST \
  http://${host}:${port}/run/script \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/x-www-form-urlencoded' \
  -H 'postman-token: 961c65e5-bcd2-f4d4-937d-feb4b3594908' \
  -d 'sql=load%20parquet.%60filename%60%20options%20owner%20%3D%20%22userA%22%20as%20tableName%3B&timeout=1200000&owner=chenfu%40dxy.cn&allPathPrefix=%7B%0A%20%20%22userA%22%3A%20%22%2Fuser%2FuaerA%2Fskone-userA%22%2C%0A%20%20%22chenfu%22%3A%20%22%2Fuser%2Fchenfu%2Ftmp%2Fskone-chenfu%22%0A%7D&defaultPathPrefix=%2Fuser%2Fchenfu%2Ftmp%2Fskone-chenfu'
```
参数详情

|key|value|
| --- | --- |
|sql|load parquet.  `` ` `` filename`` ` `` options owner = "userA" as tableName;|
|allPathPrefix|{"userA": "/user/uaerA/skone-userA", "chenfu": "/user/chenfu/tmp/skone-chenfu"}|
|defaultPathPrefix|/user/chenfu/tmp/skone-chenfu|