### PR TITLE
支持流式xql

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/DslAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/DslAdaptor.scala
@@ -5,9 +5,11 @@ import streaming.dsl.parser.DSLSQLParser.SqlContext
 /**
   * Created by allwefantasy on 27/8/2017.
   */
-trait DslAdaptor {
+trait DslAdaptor extends DslTool {
   def parse(ctx: SqlContext): Unit
+}
 
+trait DslTool {
   def cleanStr(str: String) = {
     if (str.startsWith("`") || str.startsWith("\""))
       str.substring(1, str.length - 1)

--- a/streamingpro-spark-2.0/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/rest/RestController.scala
@@ -92,8 +92,8 @@ class RestController extends ApplicationController {
         })
       } else {
         StreamingproJobManager.run(sparkSession, jobInfo, () => {
-          val allPathPrefix = fromJson(param("allPathPrefix"), classOf[Map[String, String]])
-          val defaultPathPrefix = param("defaultPathPrefix")
+          val allPathPrefix = fromJson(param("allPathPrefix", "{}"), classOf[Map[String, String]])
+          val defaultPathPrefix = param("defaultPathPrefix", "")
           ScriptSQLExec.parse(param("sql"), new ScriptSQLExecListener(sparkSession, defaultPathPrefix, allPathPrefix))
         })
       }


### PR DESCRIPTION
```sql
-- 加载卡夫卡
load kafka9.`` where `kafka.bootstrap.servers`="127.0.0.1:9092"
and `topics`="testM"
as newkafkatable1;

-- 获取所有数据
select * from newkafkatable
as table21;

--保存并且设置周期等
save append table21  
as json.`/tmp/abc2` 
options mode="Append"
and duration="10"
and checkpointLocation="/tmp/cpl2";
```

可以启动一个StreamingPro server,然后通过rest接口提交该流式脚本。

另外newkafkatable1的表结构如下：

```
private[kafka08] object KafkaSource {
  private[kafka08] val VERSION = 8
  def kafkaSchema: StructType = StructType(Seq(
    StructField("key", BinaryType),
    StructField("value", BinaryType),
    StructField("topic", StringType),
    StructField("partition", IntegerType),
    StructField("offset", LongType)
  ))
}
```