### PR TITLE
允许罗列或者杀死当前流式任务

### DIFF
--- a/streamingpro-spark-common/src/main/java/streaming/core/StreamingproJobManager.scala
+++ b/streamingpro-spark-common/src/main/java/streaming/core/StreamingproJobManager.scala
@@ -110,6 +110,7 @@ class StreamingproJobManager(sc: SparkContext, initialDelay: Long, checkTimeInte
 case object StreamingproJobType {
   val SCRIPT = "script"
   val SQL = "sql"
+  val STREAM = "stream"
 }
 
 case class StreamingproJobInfo(


### PR DESCRIPTION
通过接口：

```
http://ip:port/stream/jobs/running
```
查看所有流式计算任务。

通过接口：

```
http://ip:port/stream/jobs/kill?groupId=....
```

可以杀死正在运行的流式任务