### PR TITLE
更新carbondata版本

### DIFF
--- a/streamingpro-spark-2.0/pom.xml
+++ b/streamingpro-spark-2.0/pom.xml
@@ -76,12 +76,17 @@
                 <dependency>
                     <groupId>org.apache.carbondata</groupId>
                     <artifactId>carbondata-spark2</artifactId>
-                    <version>1.2.0</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-repl_2.11</artifactId>
-                    <version>${spark.version}</version>
+                    <version>1.3.1</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-repl_2.11</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-repl_2.11</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>

--- a/streamingpro-spark-2.0/src/main/java/streaming/core/LoalSparkServiceApp.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/core/LoalSparkServiceApp.scala
@@ -16,7 +16,7 @@ object LocalSparkServiceApp {
       "-streaming.spark.service", "true",
       "-streaming.job.cancel", "true",
       "-streaming.ps.enable", "true",
-      "-streaming.enableCarbonDataSupport", "false",
+      "-streaming.enableCarbonDataSupport", "true",
       "-streaming.carbondata.store", "/data/carbon/store",
       "-streaming.carbondata.meta", "/data/carbon/meta",
       "-spark.sql.hive.thriftServer.singleSession", "true",

--- a/streamingpro-spark-2.0/src/main/java/streaming/core/compositor/spark/udf/Functions.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/core/compositor/spark/udf/Functions.scala
@@ -187,5 +187,10 @@ object Functions {
     })
   }
 
+  def decodeKafka(uDFRegistration: UDFRegistration) = {
+    uDFRegistration.register("decodeKafka", (item: Array[Byte]) => {
+      new String(item, "utf-8")
+    })
+  }
 
 }


### PR DESCRIPTION
启动时添加下面参数开启carbondata支持

```
-streaming.enableCarbonDataSupport true
-streaming.carbondata.store  "/data/carbon/store"
-streaming.carbondata.meta "/data/carbon/meta"
```

通过/run/sql 创建一张表：

```
CREATE TABLE carbon_table2 (
      col1 STRING,
      col2 STRING
      )
      STORED BY 'carbondata'
      TBLPROPERTIES('streaming'='true')

```

/run/script提交一个流式程序：

```sql
set streamName="streamExample";
load kafka9.`-` where `kafka.bootstrap.servers`="127.0.0.1:9092"
and `topics`="testM"
as newkafkatable1;

select "abc" as col1,decodeKafka(value) as col2 from newkafkatable1
as table21;

save append table21  
as carbondata.`-` 
options mode="append"
and duration="10"
and dbName="default"
and tableName="carbon_table2"
and `carbon.stream.parser`="org.apache.carbondata.streaming.parser.RowStreamParserImp"
and checkpointLocation="/data/carbon/store/default/carbon_table2/.streaming/checkpoint";
```
通过 `/stream/jobs/running` 查看是否正常运行。

通过 `run/sql`查看结果表：

```sql
select * from carbon_table2
```

查询结果如下：

```json
[
    {
        "col1": "abc"
    },
    {
        "col1": "abc"
    },
    {
        "col1": "abc"
    },
    {
        "col1": "abc"
    },
    {
        "col1": "abc",
        "col2": "今天才是我的dafk"
    },
    {
        "col1": "abc",
        "col2": "dakfea"
    },
    {
        "col1": "abc",
        "col2": "afek"
    },
    {
        "col1": "abc",
        "col2": "dafkea"
    },
    {
        "col1": "abc",
        "col2": "dafkea"
    }
]
```


