### PR TITLE
添加一个工具类-TokenExtract

### DIFF
--- a/docs/mlsql.md
+++ b/docs/mlsql.md
@@ -408,3 +408,27 @@ register DicOrTableToArray.`/tmp/model2` as p2;
 ```
 select p2("dic2")  as k
 ```
+
+## TokenExtract
+
+该模型集成了ansj_seg 分词包,主要用于查看文本中哪些词是在词典当中，会比正则快非常多。
+你需要在启动StreamingPro的过程中额外通过--jars 带上ansj_seg all in one jar包。 
+
+
+```sql
+-- 待处理文本
+select "你好啊我是天才" as words ,"1" as id
+as newdata;
+
+-- 指定词典，然后TokenExtract 会在/tmp/model生成一个parquet文件，包含id和keywords两个字段。
+-- id 是你指定的内容的唯一标号，需要是字符串类型。
+-- keywords则是你指定的文本列里抽取出来的在字典中的词汇。
+
+train newdata as TokenExtract.`/tmp/model` where 
+`dic.paths`="/tmp/abc.txt"
+and idCol="id"
+and inputCol="words";
+
+load parquet.`/tmp/model` as tb;
+select * from tb;
+```

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -57,7 +57,8 @@ object MLMapping {
     "SKLearn" -> "streaming.dsl.mmlib.algs.SQLSKLearn",
     "DicOrTableToArray" -> "streaming.dsl.mmlib.algs.SQLDicOrTableToArray",
     "TableToMap" -> "streaming.dsl.mmlib.algs.SQLTableToMap",
-    "DL4J" -> "streaming.dsl.mmlib.algs.SQLDL4J"
+    "DL4J" -> "streaming.dsl.mmlib.algs.SQLDL4J",
+    "TokenExtract" -> "streaming.dsl.mmlib.algs.SQLTokenExtract"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLTokenExtract.scala
+++ b/streamingpro-spark-2.0/src/main/java/streaming/dsl/mmlib/algs/SQLTokenExtract.scala
@@ -1,0 +1,61 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.{ArrayType, StringType, StructField, StructType}
+import streaming.dsl.mmlib.SQLAlg
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Created by allwefantasy on 24/4/2018.
+  */
+class SQLTokenExtract extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val session = df.sparkSession
+    var result = Array[String]()
+    require(params.contains("dic.paths"), "dic.paths is required")
+    require(params.contains("inputCol"), "inputCol is required")
+    require(params.contains("idCol"), "idCol is required")
+    val fieldName = params("inputCol")
+    val idCol = params("idCol")
+    result ++= params("dic.paths").split(",").map { f =>
+      val wordsList = session.sparkContext.textFile(f).collect()
+      wordsList
+    }.flatMap(f => f)
+    val ber = session.sparkContext.broadcast(result)
+    val rdd = df.rdd.mapPartitions { mp =>
+
+      val forest = Class.forName("org.nlpcn.commons.lang.tire.domain.SmartForest").newInstance()
+      ber.value.foreach { f =>
+        forest.getClass.getMethod("add", classOf[String], classOf[Object]).invoke(forest, f, new Integer(1))
+      }
+      mp.map { f =>
+        val content = f.getAs[String](fieldName)
+        val id = f.getAs[String](idCol)
+        //val udg = forest.getWord(q.query.toLowerCase.toCharArray)
+        val udg = forest.getClass.getMethod("getWord", classOf[String]).invoke(forest, content.toLowerCase)
+        def getAllWords(udg: Any) = {
+          udg.getClass.getMethod("getAllWords").invoke(udg).asInstanceOf[String]
+        }
+        var tempWords = ArrayBuffer[String]()
+        var temp = getAllWords(udg)
+        while (temp != null) {
+          tempWords += temp
+          temp = getAllWords(udg)
+        }
+        Row.fromSeq(Seq(id, tempWords))
+      }
+    }
+    session.createDataFrame(rdd, StructType(Seq(StructField("id", StringType), StructField("keywords", ArrayType(StringType))))).
+      write.mode(SaveMode.Overwrite).parquet(path)
+  }
+
+  override def load(sparkSession: SparkSession, path: String): Any = {
+    null
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String): UserDefinedFunction = {
+    null
+  }
+}


### PR DESCRIPTION
## TokenExtract

该模型集成了ansj_seg 分词包,主要用于查看文本中哪些词是在词典当中，会比正则快非常多。
你需要在启动StreamingPro的过程中额外通过--jars 带上ansj_seg all in one jar包。 


```sql
-- 待处理文本
select "你好啊我是天才" as words ,"1" as id
as newdata;

-- 指定词典，然后TokenExtract 会在/tmp/model生成一个parquet文件，包含id和keywords两个字段。
-- id 是你指定的内容的唯一标号，需要是字符串类型。
-- keywords则是你指定的文本列里抽取出来的在字典中的词汇。

train newdata as TokenExtract.`/tmp/model` where 
`dic.paths`="/tmp/abc.txt"
and idCol="id"
and inputCol="words";

load parquet.`/tmp/model` as tb;
select * from tb;
```