### PR TITLE
流式写入parquet时，允许path路径定义时间格式变量

### DIFF
--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/sql/execution/streaming/newfile/NewFileSource.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/sql/execution/streaming/newfile/NewFileSource.scala
@@ -1,0 +1,23 @@
+package org.apache.spark.sql.execution.streaming.newfile
+
+import org.apache.spark.sql.{AnalysisException, SQLContext}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.streaming.{FileStreamSink, Sink}
+import org.apache.spark.sql.sources.StreamSinkProvider
+import org.apache.spark.sql.streaming.OutputMode
+
+/**
+  * Created by allwefantasy on 22/5/2018.
+  */
+class DefaultSource extends StreamSinkProvider {
+  override def createSink(sqlContext: SQLContext, parameters: Map[String, String], partitionColumns: Seq[String], outputMode: OutputMode): Sink = {
+    val path = parameters.getOrElse("path", {
+      throw new IllegalArgumentException("'path' is not specified")
+    })
+    if (outputMode != OutputMode.Append) {
+      throw new AnalysisException(
+        s"Data source ${getClass.getCanonicalName} does not support $outputMode output mode")
+    }
+    new NewFileStreamSink(sqlContext.sparkSession, parameters("path"), new ParquetFileFormat(), partitionColumns, parameters)
+  }
+}

--- a/streamingpro-spark-2.0/src/main/java/org/apache/spark/sql/execution/streaming/newfile/NewFileStreamSink.scala
+++ b/streamingpro-spark-2.0/src/main/java/org/apache/spark/sql/execution/streaming/newfile/NewFileStreamSink.scala
@@ -1,0 +1,67 @@
+package org.apache.spark.sql.execution.streaming.newfile
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.sql.execution.datasources.{FileFormat, FileFormatWriter}
+import org.apache.spark.sql.execution.streaming.{FileStreamSink, FileStreamSinkLog, ManifestFileCommitProtocol, Sink}
+import org.apache.spark.sql.{SparkSession, _}
+import _root_.streaming.common.RenderEngine
+import org.joda.time.DateTime
+
+class NewFileStreamSink(
+                         sparkSession: SparkSession,
+                         _path: String,
+                         fileFormat: FileFormat,
+                         partitionColumnNames: Seq[String],
+                         options: Map[String, String]) extends Sink with Logging {
+
+  def evaluate(value: String, context: Map[String, AnyRef]) = {
+    RenderEngine.render(value, context)
+  }
+
+  def path = {
+    evaluate(_path, Map("date" -> new DateTime()))
+  }
+
+  private def basePath = new Path(path)
+
+  private def logPath = new Path(basePath, FileStreamSink.metadataDir)
+
+  private def fileLog =
+    new FileStreamSinkLog(FileStreamSinkLog.VERSION, sparkSession, logPath.toUri.toString)
+
+  private val hadoopConf = sparkSession.sessionState.newHadoopConf()
+
+  override def addBatch(batchId: Long, data: DataFrame): Unit = {
+    if (batchId <= fileLog.getLatest().map(_._1).getOrElse(-1L)) {
+      logInfo(s"Skipping already committed batch $batchId")
+    } else {
+      val committer = FileCommitProtocol.instantiate(
+        className = sparkSession.sessionState.conf.streamingFileCommitProtocolClass,
+        jobId = batchId.toString,
+        outputPath = path,
+        isAppend = false)
+
+      committer match {
+        case manifestCommitter: ManifestFileCommitProtocol =>
+          manifestCommitter.setupManifestOptions(fileLog, batchId)
+        case _ => // Do nothing
+      }
+
+      FileFormatWriter.write(
+        sparkSession = sparkSession,
+        queryExecution = data.queryExecution,
+        fileFormat = fileFormat,
+        committer = committer,
+        outputSpec = FileFormatWriter.OutputSpec(path, Map.empty),
+        hadoopConf = hadoopConf,
+        partitionColumnNames = partitionColumnNames,
+        bucketSpec = None,
+        refreshFunction = _ => (),
+        options = options)
+    }
+  }
+
+  override def toString: String = s"FileSink[$path]"
+}


### PR DESCRIPTION
```sql
set streamName="streamExample";

load kafka.`-` options `kafka.bootstrap.servers`="127.0.0.1:9092"
and `subscribe`="testM"
as newkafkatable1;

select "abc" as col1,decodeKafka(value) as col2 from newkafkatable1
as table21;

save append table21  
as newparquet.`/tmp/jack/hp_date=${date.toString("yyyy-MM-dd")}` 
options mode="append"
and duration="10"
and implClass="org.apache.spark.sql.execution.streaming.newfile"
and checkpointLocation="/tmp/abc";
```