### PR TITLE
建立两个子模块，方便对sparkAPI做适配

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <module>streamingpro-dl4j</module>
         <module>streamingpro-tensorflow</module>
         <module>streamingpro-opencv</module>
+        <module>streamingpro-spark-2.2.0-adaptor</module>
+        <module>streamingpro-spark-2.3.0-adaptor</module>
     </modules>
 
     <properties>

--- a/streamingpro-spark-2.0/src/test/java/streaming/core/PythonMLSpec.scala
+++ b/streamingpro-spark-2.0/src/test/java/streaming/core/PythonMLSpec.scala
@@ -183,11 +183,12 @@ class PythonMLSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQ
           |    print(pickle.loads(items[1])[0])
           |    model = pickle.load(open(pickle.loads(items[1])[0]+"/model.pickle"))
           |    y = model.predict([feature.toArray()])
+          |    print("------".format)
           |    return [VectorUDT().serialize(Vectors.dense(y))]
           |
           |
           |python_fun.udf(predict)
-          |""".stripMargin
+          | """.stripMargin
 
       writeStringToFile("/tmp/sklearn-user-script.py", pythonCode)
       writeStringToFile("/tmp/sklearn-user-predict-script.py", pythonPridcitCode)

--- a/streamingpro-spark-2.2.0-adaptor/pom.xml
+++ b/streamingpro-spark-2.2.0-adaptor/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streamingpro</artifactId>
+        <groupId>streaming.king</groupId>
+        <version>1.1.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streamingpro-spark-2.2.0-adaptor</artifactId>
+
+
+</project>

--- a/streamingpro-spark-2.3.0-adaptor/pom.xml
+++ b/streamingpro-spark-2.3.0-adaptor/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streamingpro</artifactId>
+        <groupId>streaming.king</groupId>
+        <version>1.1.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streamingpro-spark-2.3.0-adaptor</artifactId>
+
+
+</project>


### PR DESCRIPTION
目前尝试兼容2.2.0,2.3.0。 1.6.0版本相关功能不再做进一步支持。