### PR TITLE
允许python预测脚本获取所有训练时配置参数

### DIFF
--- a/streamingpro-mlsql/src/test/java/streaming/core/PythonMLSpec.scala
+++ b/streamingpro-mlsql/src/test/java/streaming/core/PythonMLSpec.scala
@@ -103,6 +103,8 @@ class PythonMLSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQ
           |    items = [i for i in s]
           |    feature = VectorUDT().deserialize(pickle.loads(items[0]))
           |    modelPath = pickle.loads(items[1])[0]+"/model.pickle"
+          |    trainParams = pickle.loads(items[2])[0]
+          |    print(trainParams)
           |    print("predict.....")
           |    if not hasattr(os,"models"):
           |       setattr(os,"models",{})
@@ -240,13 +242,13 @@ class PythonMLSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQ
     }
   }
 
-//  "python-alg-tensorflow-cnn-model" should "work fine" in {
-//    withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
-//      //执行sql
-//      implicit val spark = runtime.sparkSession
-//      val sq = createSSEL
-//      ScriptSQLExec.parse(loadSQLScriptStr("python-alg-tensorflow-cnn"), sq)
-//
-//    }
-//  }
+  //  "python-alg-tensorflow-cnn-model" should "work fine" in {
+  //    withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
+  //      //执行sql
+  //      implicit val spark = runtime.sparkSession
+  //      val sq = createSSEL
+  //      ScriptSQLExec.parse(loadSQLScriptStr("python-alg-tensorflow-cnn"), sq)
+  //
+  //    }
+  //  }
 }


### PR DESCRIPTION
可以通过如下方式获取训练参数：

```
def predict(index, items):
    modelPath = pickle.loads(items[1])[0] + "/model.h5"

    if not hasattr(os, "mlsql_models"):
        setattr(os, "mlsql_models", {})
    if modelPath not in os.mlsql_models:
        print("Load sklearn model %s" % modelPath)
        os.mlsql_models[modelPath] = load_model(modelPath)
    # here we can get train params
    trainParams = pickle.loads(items[2])[0]
    width = int(trainParams["width"])
    height = int(trainParams["height"])
```