### PR TITLE
多模型训练时，允许用户自定义选择某个模型进行注册

### DIFF
--- a/streamingpro-mlsql/src/main/resources-local/test/sql/python-alg-script.sql
+++ b/streamingpro-mlsql/src/main/resources-local/test/sql/python-alg-script.sql
@@ -17,6 +17,7 @@ and `systemParam.pythonVer`="2.7"
 
 register PythonAlg.`/tmp/pa_model` as jack options
 pythonScriptPath="${pythonPredictScriptPath}"
+and algIndex="0"
 ;
 
 select jack(features) from data


### PR DESCRIPTION
```sql
load libsvm.`sample_libsvm_data.txt` as data;

train data as PythonAlg.`/tmp/pa_model`
where
pythonScriptPath="${pythonScriptPath}"
and `kafkaParam.bootstrap.servers`="127.0.0.1:9092"
and `kafkaParam.topic`="test"
and `kafkaParam.group_id`="g_test-1"
and `kafkaParam.userName`="zhuhl"
and  `fitParam.0.batchSize`="1000"
and  `fitParam.0.labelSize`="2"
and validateTable="data"
and `systemParam.pythonPath`="python"
and `systemParam.pythonParam`="-u"
and `systemParam.pythonVer`="2.7"
;

register PythonAlg.`/tmp/pa_model` as jack options
pythonScriptPath="${pythonPredictScriptPath}"
-- 这里可以选择第一个模型进行注册
and algIndex="0"
;

select jack(features) from data
as newdata;
```