### PR TITLE
[MLSQL][add] 自定义python算法支持自定义资源文件

### DIFF
--- a/docs/mlsql-user-defined-alg.md
+++ b/docs/mlsql-user-defined-alg.md
@@ -267,4 +267,27 @@ if __name__ == '__main__':
 这些数据存储在HDFS上，根据需要会分发到各个executor节点的/tmp/\_\_mlsql\_\_ 目录。
 
 
+## 参数说明
 
+### fitParam.[number].resource.[resourceName]
+
+`PythonAlg`模块指定特殊的数据源，比如我们可能在算法中需要到一个字典文件。我们可以通过`resource`配置来指定相应的资源文件，系统会将自动分发到运行的节点上。
+
+```sql
+-- 一些配置参数
+and  `fitParam.0.batchSize`="1000"
+and  `fitParam.0.labelSize`="2"
+and `fitParam.0.resource.a`="/path/to/resource/a"
+and `fitParam.0.resource.b`="/path/to/resource/b"
+```
+
+> NOTE: `resource`配置支持多个资源文件路径
+
+配置完成之后，我们可以在python脚本中这样使用：
+
+```python
+print(mlsql.internal_system_param['resource']['a'])
+print(mlsql.internal_system_param['resource']['b'])
+```
+
+如果在训练参数重配置了资源文件，那么系统将自动在预测时候加载该资源文件，使用方式同训练方法。

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/Functions.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/Functions.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 /**
   * Created by allwefantasy on 13/1/2018.
   */
-trait Functions extends SQlBaseFunc{
+trait Functions extends SQlBaseFunc {
   val logger = Loggers.getLogger(getClass)
 
   def sampleUnbalanceWithMultiModel(df: DataFrame, path: String, params: Map[String, String], train: (DataFrame, Int) => Unit) = {
@@ -98,13 +98,13 @@ trait Functions extends SQlBaseFunc{
   }
 
   def mapParams(name: String, params: Map[String, String]) = {
-    params.filter(f => f._1.startsWith(name + ".")).map(f => (f._1.split("\\.").drop(1).mkString("."), f._2))
+    Functions.mapParams(name, params)
   }
 
   def arrayParams(name: String, params: Map[String, String]) = {
     params.filter(f => f._1.startsWith(name + ".")).map { f =>
-      val Array(name, group, key) = f._1.split("\\.")
-      (group, key, f._2)
+      val Array(name, group, keys @ _*) = f._1.split("\\.")
+      (group, keys.mkString("."), f._2)
     }.groupBy(f => f._1).map { f => f._2.map(k =>
       (k._2, k._3)).toMap
     }.toArray
@@ -112,8 +112,8 @@ trait Functions extends SQlBaseFunc{
 
   def arrayParamsWithIndex(name: String, params: Map[String, String]): Array[(Int, Map[String, String])] = {
     params.filter(f => f._1.startsWith(name + ".")).map { f =>
-      val Array(name, group, key) = f._1.split("\\.")
-      (group, key, f._2)
+      val Array(name, group, keys @ _*) = f._1.split("\\.")
+      (group, keys.mkString("."), f._2)
     }.groupBy(f => f._1).map( f => {
       val params = f._2.map(k => (k._2, k._3)).toMap
       (f._1.toInt, params)
@@ -247,5 +247,10 @@ trait Functions extends SQlBaseFunc{
       psDriverBackend.psDriverRpcEndpointRef.askSync[Boolean](Message.CopyModelToLocal(path, tempLocalPath))
     }
   }
-
+}
+object Functions {
+  def mapParams(name: String, params: Map[String, String]) = {
+    //    params.filter(f => f._1.startsWith(name + ".")).map(f => (f._1.split("\\.").drop(1).mkString("."), f._2))
+    params.filter(f => f._1.startsWith(name + ".")).map(f => (f._1.substring(name.length + 1, f._1.length), f._2))
+  }
 }

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPythonFunc.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPythonFunc.scala
@@ -95,6 +95,10 @@ object SQLPythonFunc {
     s"${getLocalBasePath}/data/${WowMD5.md5Hash(hdfsPath)}"
   }
 
+  def getLocalTempResourcePath(hdfsPath: String, resourceName: String) = {
+    s"${getLocalBasePath}/resource/${WowMD5.md5Hash(hdfsPath)}/${resourceName}"
+  }
+
   def getLocalBasePath = {
     s"/tmp/__mlsql__"
   }


### PR DESCRIPTION
fix #304 

### fitParam.[number].resource.[resourceName]

`PythonAlg`模块指定特殊的数据源，比如我们可能在算法中需要到一个字典文件。我们可以通过`resource`配置来指定相应的资源文件，系统会将自动分发到运行的节点上。

```sql
-- 一些配置参数
and  `fitParam.0.batchSize`="1000"
and  `fitParam.0.labelSize`="2"
and `fitParam.0.resource.a`="/path/to/resource/a"
and `fitParam.0.resource.b`="/path/to/resource/b"
```

> NOTE: `resource`配置支持多个资源文件路径

配置完成之后，我们可以在python脚本中这样使用：

```python
print(mlsql.internal_system_param['resource']['a'])
print(mlsql.internal_system_param['resource']['b'])
```

如果在训练参数重配置了资源文件，那么系统将自动在预测时候加载该资源文件，使用方式同训练方法。
