### PR TITLE
对/download /model/predict等接口允许通过配置进行拦截，从而实现一些权限方面的限制

### DIFF
--- a/streamingpro-api/src/main/java/streaming/rest/ExampleRestInterceptor.scala
+++ b/streamingpro-api/src/main/java/streaming/rest/ExampleRestInterceptor.scala
@@ -1,0 +1,20 @@
+package streaming.rest
+
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import net.csdn.common.exception.RenderFinish
+
+/**
+  * Created by allwefantasy on 27/7/2018.
+  */
+class ExampleRestInterceptor extends RestInterceptor {
+  override def before(request: HttpServletRequest, response: HttpServletResponse): Unit = {
+    if (request.getPathInfo == "/download") {
+      val username = request.getParameter("username")
+      if (username == null) {
+        response.getWriter.write("username is required")
+        throw new RenderFinish()
+      }
+    }
+  }
+}

--- a/streamingpro-api/src/main/java/streaming/rest/RestInterceptor.scala
+++ b/streamingpro-api/src/main/java/streaming/rest/RestInterceptor.scala
@@ -1,0 +1,10 @@
+package streaming.rest
+
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+/**
+  * Created by allwefantasy on 27/7/2018.
+  */
+trait RestInterceptor {
+  def before(request: HttpServletRequest, response: HttpServletResponse)
+}

--- a/streamingpro-mlsql/src/main/java/streaming/core/LoalSparkServiceApp.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/LoalSparkServiceApp.scala
@@ -16,7 +16,9 @@ object LocalSparkServiceApp {
       "-streaming.job.cancel", "true",
       "-streaming.ps.enable", "true",
       "-spark.sql.hive.thriftServer.singleSession", "true",
+      "-streaming.rest.intercept.clzz", "streaming.rest.ExampleRestInterceptor",
       "-streaming.driver.port", "9003"
+
       //"-streaming.sql.out.path","file:///tmp/test/pdate=20160809"
 
       //"-streaming.jobs","idf-compute"

--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestPredictController.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestPredictController.scala
@@ -17,6 +17,7 @@ class RestPredictController extends ApplicationController {
 
   @At(path = Array("/model/predict"), types = Array(GET, POST))
   def modelPredict = {
+    intercept()
     val res = param("dataType", "vector") match {
       case "vector" => vec2vecPredict
       case "string" => string2vecPredict
@@ -83,5 +84,13 @@ class RestPredictController extends ApplicationController {
   }
 
   def runtime = PlatformManager.getRuntime
+
+  def intercept() = {
+    val jparams = runtime.asInstanceOf[SparkRuntime].params
+    if (jparams.containsKey("streaming.rest.intercept.clzz")) {
+      val interceptor = Class.forName(jparams("streaming.rest.intercept.clzz").toString).newInstance()
+      interceptor.asInstanceOf[RestInterceptor].before(request = request.httpServletRequest(), response = restResponse.httpServletResponse())
+    }
+  }
 }
 


### PR DESCRIPTION
内置的 /download 接口允许下载hdfs上的文件或者目录
内置的/model/predict 接口则允许使用已经注册的模型。

这两个接口都是http接口，没有任何权限校验，有一定的分享。通过该PR放出的接口，用户可以很好的嵌入包括权限校验相关的代码进去。具体做法是,在自己项目中引入 streamingpro-api,然后实现streaming.rest.RestInterceptor 接口：

```
package streaming.rest

import javax.servlet.http.{HttpServletRequest, HttpServletResponse}

import net.csdn.common.exception.RenderFinish

/**
  * Created by allwefantasy on 27/7/2018.
  */
class ExampleRestInterceptor extends RestInterceptor {
  override def before(request: HttpServletRequest, response: HttpServletResponse): Unit = {
    if (request.getPathInfo == "/download") {
      val username = request.getParameter("username")
      if (username == null) {
        response.getWriter.write("username is required")
        throw new RenderFinish()
      }
    }
  }
}
```

打包，启动streamingpro时通过--jars带上对应的jar包，并且在启动命令行中添加如下配置：

```
-streaming.rest.intercept.clzz  "streaming.rest.ExampleRestInterceptor",
```

之后就可以拦截download接口了
