### PR TITLE
优化Spark部署成API时请求性能

### DIFF
--- a/streamingpro-commons/src/main/java/streaming/common/JSONTool.scala
+++ b/streamingpro-commons/src/main/java/streaming/common/JSONTool.scala
@@ -1,0 +1,27 @@
+package streaming.common
+
+import net.liftweb.{json => SJSon}
+import net.sf.json.{JSONArray, JSONObject}
+
+/**
+  * Created by allwefantasy on 2/8/2018.
+  */
+object JSONTool {
+  def parseJson[T](str: String)(implicit m: Manifest[T]) = {
+    implicit val formats = SJSon.DefaultFormats
+    SJSon.parse(str).extract[T]
+  }
+
+  def toJsonStr(item: AnyRef) = {
+    implicit val formats = SJSon.Serialization.formats(SJSon.NoTypeHints)
+    SJSon.Serialization.write(item)
+  }
+
+  def toJsonList4J(item: Object) = {
+    JSONArray.fromObject(item).toString
+  }
+
+  def toJsonMap4J(item: Object) = {
+    JSONObject.fromObject(item).toString
+  }
+}

--- a/streamingpro-commons/src/main/java/streaming/common/TimeRecord.scala
+++ b/streamingpro-commons/src/main/java/streaming/common/TimeRecord.scala
@@ -1,0 +1,117 @@
+package streaming.common
+
+import net.sf.json.{JSONArray, JSONObject}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
+
+/**
+  * Created by allwefantasy on 31/7/2018.
+  */
+class TimeRecord(debug: Boolean) {
+  private val list = new ArrayBuffer[DurationItem]()
+  private var lastPunchItem: Option[PunchItem] = None
+  private var children = new ArrayBuffer[TimeRecord]()
+  private var parent: Option[TimeRecord] = None
+
+  def stepIn(async: Boolean = false) = {
+    if (!debug) {
+      null
+    } else {
+      synchronized {
+        val tr = new TimeRecord(debug)
+        tr.parent = Some(this)
+        children += tr
+        val v = TimeRecord.stack.get()
+        if (v == null) {
+          TimeRecord.setStack(new mutable.Stack[TimeRecordWrapper]())
+        }
+        TimeRecord.stack.get().push(TimeRecordWrapper(async, tr))
+        tr
+      }
+    }
+
+  }
+
+  def stepOut = {
+    //this.parent.get
+  }
+
+  def renew = {
+    if (!debug) {} else {
+      lastPunchItem = Some(PunchItem(System.currentTimeMillis()))
+
+    }
+    this
+  }
+
+  def punch(name: String) = {
+    if (!debug) {}
+    else {
+      val time = System.currentTimeMillis()
+      lastPunchItem match {
+        case Some(pi) =>
+          list += DurationItem(name, time - pi.time)
+        case None =>
+      }
+      lastPunchItem = Some(PunchItem(time))
+    }
+    this
+
+  }
+}
+
+object TimeRecord {
+  val stack = new ThreadLocal[mutable.Stack[TimeRecordWrapper]]()
+
+  def setStack(sk: mutable.Stack[TimeRecordWrapper]) = {
+    stack.set(sk)
+  }
+
+  def unsetStack = {
+    stack.remove()
+  }
+
+
+  def begin(debug: Boolean) = {
+    if (stack.get() == null || stack.get().isEmpty) {
+      new TimeRecord(debug)
+    } else {
+      val trW = stack.get().pop()
+      trW.timeRecord
+    }
+  }
+
+  def mixin(res: String, root: TimeRecord) = {
+
+    TimeRecord.unsetStack
+
+    def f(t: TimeRecord): ResultItem = {
+      val name = t.parent match {
+        case Some(i) => i.list.last.name
+        case None => ""
+      }
+      ResultItem(name, t.list.toList, t.children.map(tr => f(tr)).toList)
+    }
+    val time_debug = JSONTool.toJsonStr(f(root))
+    val newres = new JSONObject()
+    val tmp = try {
+      JSONArray.fromObject(res)
+    } catch {
+      case e: Exception =>
+        JSONObject.fromObject(res)
+    }
+    newres.put("data", tmp)
+    newres.put("time_debug", time_debug)
+    newres.toString()
+  }
+
+}
+
+case class TimeRecordWrapper(async: Boolean, timeRecord: TimeRecord)
+
+case class PunchItem(time: Long)
+
+case class DurationItem(name: String, time: Long)
+
+case class ResultItem(name: String, di: List[DurationItem], children: List[ResultItem])

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/api/python/WowSparkEnv.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/api/python/WowSparkEnv.scala
@@ -1,0 +1,165 @@
+package org.apache.spark.api.python
+
+import java.io._
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+import net.csdn.common.reflect.ReflectHelper
+import org.apache.spark.broadcast.BroadcastManager
+import org.apache.spark.memory.MemoryManager
+import org.apache.spark.metrics.MetricsSystem
+import org.apache.spark.{MapOutputTracker, SecurityManager, SparkConf, SparkEnv}
+import org.apache.spark.rpc.RpcEnv
+import org.apache.spark.scheduler.{OutputCommitCoordinator, TaskSchedulerImpl}
+import org.apache.spark.scheduler.local.{LocalSchedulerBackend, WowLocalSchedulerBackend}
+import org.apache.spark.serializer._
+import org.apache.spark.shuffle.ShuffleManager
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.storage.BlockManager
+import org.apache.spark.util.Utils
+
+import scala.reflect.ClassTag
+
+/**
+  * Created by allwefantasy on 5/8/2018.
+  */
+class WowSparkEnv(
+                   executorId: String,
+                   rpcEnv: RpcEnv,
+                   serializer: Serializer,
+                   closureSerializer: Serializer,
+                   serializerManager: SerializerManager,
+                   mapOutputTracker: MapOutputTracker,
+                   shuffleManager: ShuffleManager,
+                   broadcastManager: BroadcastManager,
+                   blockManager: BlockManager,
+                   securityManager: SecurityManager,
+                   metricsSystem: MetricsSystem,
+                   memoryManager: MemoryManager,
+                   outputCommitCoordinator: OutputCommitCoordinator,
+                   conf: SparkConf) extends SparkEnv(
+  executorId: String,
+  rpcEnv: RpcEnv,
+  serializer: Serializer,
+  closureSerializer: Serializer,
+  serializerManager: SerializerManager,
+  mapOutputTracker: MapOutputTracker,
+  shuffleManager: ShuffleManager,
+  broadcastManager: BroadcastManager,
+  blockManager: BlockManager,
+  securityManager: SecurityManager,
+  metricsSystem: MetricsSystem,
+  memoryManager: MemoryManager,
+  outputCommitCoordinator: OutputCommitCoordinator,
+  conf: SparkConf) {
+
+
+}
+
+object LocalNonOpSerializerInstance {
+  val maps = new java.util.concurrent.ConcurrentHashMap[String, AnyRef]()
+}
+
+class LocalNonOpSerializerInstance(javaD: SerializerInstance) extends SerializerInstance {
+
+  private def isClosure(cls: Class[_]): Boolean = {
+    cls.getName.contains("$anonfun$")
+  }
+
+  override def serialize[T: ClassTag](t: T): ByteBuffer = {
+    if (isClosure(t.getClass)) {
+      val uuid = UUID.randomUUID().toString
+      LocalNonOpSerializerInstance.maps.put(uuid, t.asInstanceOf[AnyRef])
+      ByteBuffer.wrap(uuid.getBytes())
+    } else {
+      javaD.serialize(t)
+    }
+
+  }
+
+  override def deserialize[T: ClassTag](bytes: ByteBuffer): T = {
+    val s = StandardCharsets.UTF_8.decode(bytes).toString()
+    if (LocalNonOpSerializerInstance.maps.containsKey(s)) {
+      LocalNonOpSerializerInstance.maps.remove(s).asInstanceOf[T]
+    } else {
+      bytes.flip()
+      javaD.deserialize(bytes)
+    }
+
+  }
+
+  override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T = {
+    val s = StandardCharsets.UTF_8.decode(bytes).toString()
+    if (LocalNonOpSerializerInstance.maps.containsKey(s)) {
+      LocalNonOpSerializerInstance.maps.remove(s).asInstanceOf[T]
+    } else {
+      bytes.flip()
+      javaD.deserialize(bytes, loader)
+    }
+  }
+
+  override def serializeStream(s: OutputStream): SerializationStream = {
+    javaD.serializeStream(s)
+  }
+
+  override def deserializeStream(s: InputStream): DeserializationStream = {
+    javaD.deserializeStream(s)
+  }
+}
+
+class LocalNonOpSerializer(conf: SparkConf) extends Serializer with Externalizable {
+  val javaS = new JavaSerializer(conf)
+
+  override def newInstance(): SerializerInstance = {
+    new LocalNonOpSerializerInstance(javaS.newInstance())
+  }
+
+  override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
+    javaS.writeExternal(out)
+  }
+
+  override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
+    javaS.readExternal(in)
+  }
+}
+
+object WowSparkEnv {
+
+  private def createSparkEnv = {
+    val env = SparkEnv.get
+    new WowSparkEnv(
+      env.executorId: String,
+      env.rpcEnv: RpcEnv,
+      env.serializer: Serializer,
+      new LocalNonOpSerializer(env.conf): Serializer,
+      env.serializerManager: SerializerManager,
+      env.mapOutputTracker: MapOutputTracker,
+      env.shuffleManager: ShuffleManager,
+      env.broadcastManager: BroadcastManager,
+      env.blockManager: BlockManager,
+      env.securityManager: SecurityManager,
+      env.metricsSystem: MetricsSystem,
+      env.memoryManager: MemoryManager,
+      env.outputCommitCoordinator: OutputCommitCoordinator,
+      env.conf: SparkConf)
+  }
+
+  def enhanceSparkEnvForAPIService(session: SparkSession) = {
+    SparkEnv.set(createSparkEnv)
+    val localScheduler = session.sparkContext.schedulerBackend.asInstanceOf[LocalSchedulerBackend]
+
+    val scheduler = ReflectHelper.field(localScheduler, "scheduler")
+
+    val totalCores = localScheduler.totalCores
+    localScheduler.stop()
+
+
+    val wowLocalSchedulerBackend = new WowLocalSchedulerBackend(session.sparkContext.getConf, scheduler.asInstanceOf[TaskSchedulerImpl], totalCores)
+    wowLocalSchedulerBackend.start()
+
+    ReflectHelper.field(session.sparkContext, "_schedulerBackend", wowLocalSchedulerBackend)
+
+
+  }
+}

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/scheduler/local/WowLocalSchedulerBackend.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/scheduler/local/WowLocalSchedulerBackend.scala
@@ -1,0 +1,136 @@
+package org.apache.spark.scheduler.local
+
+import java.io.File
+import java.net.URL
+import java.nio.ByteBuffer
+
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv, TaskState}
+import org.apache.spark.TaskState._
+import org.apache.spark.executor.{Executor, ExecutorBackend}
+import org.apache.spark.internal.Logging
+import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
+import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
+import org.apache.spark.scheduler.{SchedulerBackend, SparkListenerExecutorAdded, TaskSchedulerImpl, WorkerOffer}
+import org.apache.spark.scheduler.cluster.ExecutorInfo
+
+/**
+  * Created by allwefantasy on 5/8/2018.
+  */
+
+private[spark] class WowLocalEndpoint(
+                                       override val rpcEnv: RpcEnv,
+                                       userClassPath: Seq[URL],
+                                       scheduler: TaskSchedulerImpl,
+                                       executorBackend: WowLocalSchedulerBackend,
+                                       private val totalCores: Int)
+  extends ThreadSafeRpcEndpoint with Logging {
+
+  private var freeCores = totalCores
+
+  val localExecutorId = SparkContext.DRIVER_IDENTIFIER
+  val localExecutorHostname = "localhost"
+
+  private val executor = new Executor(
+    localExecutorId, localExecutorHostname, SparkEnv.get, userClassPath, isLocal = true)
+
+  override def receive: PartialFunction[Any, Unit] = {
+    case ReviveOffers =>
+      reviveOffers()
+
+    case StatusUpdate(taskId, state, serializedData) =>
+      scheduler.statusUpdate(taskId, state, serializedData)
+      if (TaskState.isFinished(state)) {
+        freeCores += scheduler.CPUS_PER_TASK
+        reviveOffers()
+      }
+
+    case KillTask(taskId, interruptThread, reason) =>
+      executor.killTask(taskId, interruptThread, reason)
+  }
+
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+    case StopExecutor =>
+      executor.stop()
+      context.reply(true)
+  }
+
+  def reviveOffers() {
+    val offers = IndexedSeq(new WorkerOffer(localExecutorId, localExecutorHostname, freeCores))
+    for (task <- scheduler.resourceOffers(offers).flatten) {
+      freeCores -= scheduler.CPUS_PER_TASK
+      executor.launchTask(executorBackend, task)
+    }
+  }
+}
+
+class WowLocalSchedulerBackend(
+                                conf: SparkConf,
+                                scheduler: TaskSchedulerImpl,
+                                val totalCores: Int)
+  extends SchedulerBackend with ExecutorBackend with Logging {
+
+  private val appId = "local-" + System.currentTimeMillis
+  private var localEndpoint: RpcEndpointRef = null
+  private val userClassPath = getUserClasspath(conf)
+  private val listenerBus = scheduler.sc.listenerBus
+  private val launcherBackend = new LauncherBackend() {
+    override def onStopRequest(): Unit = stop(SparkAppHandle.State.KILLED)
+  }
+
+  /**
+    * Returns a list of URLs representing the user classpath.
+    *
+    * @param conf Spark configuration.
+    */
+  def getUserClasspath(conf: SparkConf): Seq[URL] = {
+    val userClassPathStr = conf.getOption("spark.executor.extraClassPath")
+    userClassPathStr.map(_.split(File.pathSeparator)).toSeq.flatten.map(new File(_).toURI.toURL)
+  }
+
+  launcherBackend.connect()
+
+  override def start() {
+    scheduler.backend = this
+    val rpcEnv = SparkEnv.get.rpcEnv
+    val executorEndpoint = new WowLocalEndpoint(rpcEnv, userClassPath, scheduler, this, totalCores)
+    localEndpoint = rpcEnv.setupEndpoint("WowLocalSchedulerBackendEndpoint", executorEndpoint)
+    listenerBus.post(SparkListenerExecutorAdded(
+      System.currentTimeMillis,
+      executorEndpoint.localExecutorId,
+      new ExecutorInfo(executorEndpoint.localExecutorHostname, totalCores, Map.empty)))
+    launcherBackend.setAppId(appId)
+    launcherBackend.setState(SparkAppHandle.State.RUNNING)
+  }
+
+  override def stop() {
+    stop(SparkAppHandle.State.FINISHED)
+  }
+
+  override def reviveOffers() {
+    localEndpoint.send(ReviveOffers)
+  }
+
+  override def defaultParallelism(): Int =
+    scheduler.conf.getInt("spark.default.parallelism", totalCores)
+
+  override def killTask(
+                         taskId: Long, executorId: String, interruptThread: Boolean, reason: String) {
+    localEndpoint.send(KillTask(taskId, interruptThread, reason))
+  }
+
+  override def statusUpdate(taskId: Long, state: TaskState, serializedData: ByteBuffer) {
+    localEndpoint.send(StatusUpdate(taskId, state, serializedData))
+  }
+
+  override def applicationId(): String = appId
+
+  private def stop(finalState: SparkAppHandle.State): Unit = {
+    localEndpoint.ask(StopExecutor)
+    try {
+      launcherBackend.setState(finalState)
+    } finally {
+      launcherBackend.close()
+    }
+  }
+
+}

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/WowDataSet.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/WowDataSet.scala
@@ -1,0 +1,42 @@
+package org.apache.spark.sql
+
+import java.io.CharArrayWriter
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.json.{JSONOptions, JacksonGenerator}
+import org.joda.time.DateTime
+
+/**
+  * Created by allwefantasy on 3/8/2018.
+  */
+object WowDataSet {
+  def toJSON(d: DataFrame): Array[String] = {
+    println(DateTime.now.toString("yyyy-MM-dd HH:mm:ss,SSS"))
+    val rowSchema = d.schema
+    val sessionLocalTimeZone = d.sparkSession.sessionState.conf.sessionLocalTimeZone
+    val rdd: RDD[String] = d.queryExecution.toRdd.mapPartitions { iter =>
+      val writer = new CharArrayWriter()
+      // create the Generator without separator inserted between 2 records
+      val gen = new JacksonGenerator(rowSchema, writer,
+        new JSONOptions(Map.empty[String, String], sessionLocalTimeZone))
+      new Iterator[String] {
+        override def hasNext: Boolean = iter.hasNext
+
+        override def next(): String = {
+          gen.write(iter.next())
+          gen.flush()
+
+          val json = writer.toString
+          if (hasNext) {
+            writer.reset()
+          } else {
+            gen.close()
+          }
+          json
+        }
+      }
+    }
+    println(DateTime.now.toString("yyyy-MM-dd HH:mm:ss,SSS"))
+    rdd.collect()
+  }
+}

--- a/streamingpro-mlsql/src/main/java/streaming/core/LoalSparkServiceApp.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/LoalSparkServiceApp.scala
@@ -18,6 +18,9 @@ object LocalSparkServiceApp {
       "-spark.sql.hive.thriftServer.singleSession", "true",
       "-streaming.rest.intercept.clzz", "streaming.rest.ExampleRestInterceptor",
       "-streaming.deploy.rest.api", "true",
+      "-spark.driver.maxResultSize", "2g",
+      "-spark.serializer", "org.apache.spark.serializer.KryoSerializer",
+      "-spark.kryoserializer.buffer.max","2000m",
       "-streaming.driver.port", "9003"
 
       //"-streaming.sql.out.path","file:///tmp/test/pdate=20160809"

--- a/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -5,9 +5,10 @@ import java.util.{Map => JMap}
 import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Logger
 
+import org.apache.spark.api.python.WowSparkEnv
 
 import scala.collection.JavaConversions._
-import org.apache.spark.{SparkConf, SparkRuntimeOperator}
+import org.apache.spark.{SparkConf, SparkEnv, SparkRuntimeOperator}
 import org.apache.spark.ps.cluster.PSDriverBackend
 import org.apache.spark.ps.local.LocalPSSchedulerBackend
 import org.apache.spark.sql.SparkSession
@@ -86,6 +87,10 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
         invoke(carbonBuilder, params("streaming.carbondata.store").toString, params("streaming.carbondata.meta").toString).asInstanceOf[SparkSession]
     } else {
       sparkSession.getOrCreate()
+    }
+
+    if (params.getOrDefault("streaming.deploy.rest.api", "false").toString.toBoolean) {
+      WowSparkEnv.enhanceSparkEnvForAPIService(ss)
     }
 
     if (params.containsKey("streaming.spark.service") && params.get("streaming.spark.service").toString.toBoolean) {


### PR DESCRIPTION
Spark的任务调度开销非常大。对于一个复杂的任务，任务业务逻辑代码执行时间大约是3-7ms,但是整个spark运行的开销大概是1.3s左右。

经过详细dig发现，sparkContext里RDD转化时，会对函数进行clean操作，clean操作的过程中，默认会检查是不是能序列化（就是序列化一遍，没抛出异常就算可以序列化）。而序列化成本相当高（默认使用的JavaSerializer并且对于函数和任务序列化，是不可更改的），大约200ms左右，反复进行测试以及序列化反序列化，导致时间消耗非常大，事实上经过优化，可以减少600ms左右的请求时间。