### PR TITLE
跳过executor 执行在driver 执行，blockmanager问题

### DIFF
--- a/streamingpro-mlsql/src/main/java/org/apache/spark/APIDeployPythonRunnerEnv.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/APIDeployPythonRunnerEnv.scala
@@ -45,6 +45,6 @@ object APIDeployPythonRunnerEnv {
   }
 
   def createTaskContext() = {
-    new TaskContextImpl(0, 0, 0, 0, null, new Properties, null)
+    new TaskContextImpl(0, 0, -1024, 0, null, new Properties, null)
   }
 }


### PR DESCRIPTION
PythonAlg 模块需要使用TaskContext, 在预测模式下，StreamingPro是直接在driver端执行预测流程，如果对应的UDF函数使用了broadcast相关的数据，在blockManager 读取时会判定有没有加写锁：

```scala
def lockForReading(
      blockId: BlockId,
      blocking: Boolean = true): Option[BlockInfo] = synchronized {
    logTrace(s"Task $currentTaskAttemptId trying to acquire read lock for $blockId")
    do {
      infos.get(blockId) match {
        case None => return None
        case Some(info) =>
          if (info.writerTask == BlockInfo.NO_WRITER) {
            info.readerCount += 1
           // 这个时候会获取task的currentTaskAttemptId
            readLocksByTask(currentTaskAttemptId).add(blockId)
            logTrace(s"Task $currentTaskAttemptId acquired read lock for $blockId")
            return Some(info)
          }
      }
      if (blocking) {
        wait()
      }
    } while (blocking)
    None
  }
```

获取taskAttemptId() 的地方在这里，如果没有TaskConext,也就是driver端，那么直接返回一个BlockInfo.NON_TASK_WRITER 该值为-1024。
```scala
 private def currentTaskAttemptId: TaskAttemptId = {
    Option(TaskContext.get()).map(_.taskAttemptId()).getOrElse(BlockInfo.NON_TASK_WRITER)
  }
```

因为我们创建了一个TaskContext,但是该TaskContext里对应的值为0,所以我们只需要把对应的值改为-1024即可解决问题。