### PR TITLE
新增crawler_http接口，主要访问HTTP接口

### DIFF
--- a/streamingpro-crawler/src/main/java/streaming/crawler/udf/Functions.scala
+++ b/streamingpro-crawler/src/main/java/streaming/crawler/udf/Functions.scala
@@ -54,6 +54,12 @@ object Functions {
     })
   }
 
+  def crawler_http(uDFRegistration: UDFRegistration) = {
+    uDFRegistration.register("crawler_http", (url: String, method: String, items: Map[String, String]) => {
+      HttpClientCrawler.requestByMethod(url, method, items)
+    })
+  }
+
   def crawler_extract_xpath(uDFRegistration: UDFRegistration) = {
     uDFRegistration.register("crawler_extract_xpath", (html: String, xpath: String) => {
       if (html == null) null

--- a/streamingpro-mlsql/src/main/java/streaming/core/LoalSparkServiceApp.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/LoalSparkServiceApp.scala
@@ -22,6 +22,7 @@ object LocalSparkServiceApp {
       "-spark.serializer", "org.apache.spark.serializer.KryoSerializer",
       "-spark.sql.codegen.wholeStage", "true",
       "-spark.kryoserializer.buffer.max", "2000m",
+      "-streaming.udf.clzznames","streaming.crawler.udf.Functions",
       "-streaming.driver.port", "9003"
 
       //"-streaming.sql.out.path","file:///tmp/test/pdate=20160809"


### PR DESCRIPTION
```sql
set chatbot_url="http://abc.com/v1/chatbot";
-- select crawler_http("${chatbot_url}?core=a","get",map("q","劲椎病可以剧烈运动么")) as t as output;
select crawler_http("${chatbot_url}?core=a","post",map("q","劲椎病可以剧烈运动么")) as t as output;
```