### PR TITLE
优化流式程序语法

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/LoadAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/LoadAdaptor.scala
@@ -118,9 +118,12 @@ class StreamLoadAdaptor(scriptSQLExecListener: ScriptSQLExecListener,
   def parse = {
     var table: DataFrame = null
     val reader = scriptSQLExecListener.sparkSession.readStream
-
+    val cPath = cleanStr(path)
     format match {
       case "kafka" | "socket" =>
+        if (!cPath.isEmpty) {
+          reader.option("subscribe", cPath)
+        }
         table = reader.options(option).format(format).load()
       case "kafka8" | "kafka9" =>
         val format = "com.hortonworks.spark.sql.kafka08"
@@ -129,6 +132,9 @@ class StreamLoadAdaptor(scriptSQLExecListener: ScriptSQLExecListener,
            kafka.metadata.broker
            startingoffset smallest
          */
+        if (!cPath.isEmpty) {
+          reader.option("topics", cPath)
+        }
         table = reader.format(format).options(option).load()
       case "mockStream" =>
         val format = "org.apache.spark.sql.execution.streaming.mock.MockStreamSourceProvider"

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/SaveAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/SaveAdaptor.scala
@@ -194,7 +194,18 @@ class StreamSaveAdaptor(val scriptSQLExecListener: ScriptSQLExecListener,
     require(option.contains("duration"), "duration is required")
     require(option.contains("mode"), "mode is required")
 
-    writer = writer.format(option.getOrElse("implClass", format)).outputMode(option("mode")).
+    format match {
+      case "jdbc" => writer.format("org.apache.spark.sql.execution.streaming.JDBCSinkProvider")
+      /*
+      Supports variable in path:
+        save append post_parquet
+        as parquet.`/post/details/hp_stat_date=${date.toString("yyyy-MM-dd")}`
+       */
+      case "newParquet" => writer.format("org.apache.spark.sql.execution.streaming.newfile")
+      case _ => writer.format(option.getOrElse("implClass", format))
+    }
+
+    writer = writer.outputMode(option("mode")).
       partitionBy(partitionByCol: _*).
       options((option - "mode" - "duration"))
 


### PR DESCRIPTION
```sql
save append table21  
as NONE.`mysql1.test1` 
options mode="Complete"
and implClass="org.apache.spark.sql.execution.streaming.JDBCSinkProvider"
-- and `statement-0`="create table test1 if not exists........."
and `statement-1`="insert into wow.test1(k,c) values(?,?)"
and duration="3"
and checkpointLocation="/tmp/cpl3";
```

or 

```sql
save append table21  
as newParquet.`mysql1.test1` 
options mode="Complete"
-- and `statement-0`="create table test1 if not exists........."
and `statement-1`="insert into wow.test1(k,c) values(?,?)"
and duration="3"
and checkpointLocation="/tmp/cpl3";
```

```sql
load kafka.`` options `kafka.bootstrap.servers`="---"
and `subscribe`="pi-content-realtime-db"
as kafka_post_parquet;
```
or 
```sql
load kafka.`pi-content-realtime-db` options `kafka.bootstrap.servers`="---"
as kafka_post_parquet;
```