### PR TITLE
添加新的内置变量${HOME}

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/ScriptSQLExec.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/ScriptSQLExec.scala
@@ -59,6 +59,8 @@ object ScriptSQLExec {
 class ScriptSQLExecListener(_sparkSession: SparkSession, _defaultPathPrefix: String, _allPathPrefix: Map[String, String]) extends DSLSQLListener {
 
   private val _env = new scala.collection.mutable.HashMap[String, String]
+  _env.put("HOME", pathPrefix(None))
+
   private val lastSelectTable = new AtomicReference[String]()
 
   def setLastSelectTable(table: String) = {

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPythonAlgBatchPrediction.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPythonAlgBatchPrediction.scala
@@ -58,14 +58,16 @@ class SQLPythonAlgBatchPrediction extends SQLAlg with Functions {
 
 
     val sessionLocalTimeZone = df.sparkSession.sessionState.conf.sessionLocalTimeZone
+    val hdfsModelPath = fitParam("modelPath")
 
+    require(!hdfsModelPath.contains(".."), "modelPath should not contains relative path")
 
     val wowRDD = df.rdd.mapPartitionsWithIndex { (algIndex, data) =>
 
       val pythonPath = systemParam.getOrElse("pythonPath", "python")
       val pythonVer = systemParam.getOrElse("pythonVer", "2.7")
       val pythonParam = systemParam.getOrElse("pythonParam", "").split(",").filterNot(f => f.isEmpty)
-      val hdfsModelPath = fitParam("modelPath")
+
 
       val tempDataLocalPath = SQLPythonFunc.getLocalTempDataPath(wowPath)
       val tempModelLocalPath = s"${SQLPythonFunc.getLocalBasePath}/${UUID.randomUUID().toString}/${algIndex}"

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/template/TemplateMerge.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/template/TemplateMerge.scala
@@ -18,8 +18,8 @@ object TemplateMerge {
       "tomorrow" -> DateTime.now().plusDays(1).toString(dformat),
       "theDayBeforeYesterday" -> DateTime.now().minusDays(2).toString(dformat)
     )
-    val newRoot = predified_variables ++ root
+    val newRoot = Map("date" -> new DateTime()) ++ predified_variables ++ root
 
-    RenderEngine.render(sql, newRoot ++ Map("date" -> new DateTime()))
+    RenderEngine.render(sql, newRoot)
   }
 }

--- a/streamingpro-mlsql/src/main/resources-local/test/sql/python-alg-batch-predict.sql
+++ b/streamingpro-mlsql/src/main/resources-local/test/sql/python-alg-batch-predict.sql
@@ -8,7 +8,7 @@ and `kafkaParam.bootstrap.servers`="127.0.0.1:9092"
 and `kafkaParam.topic`="test"
 and `kafkaParam.group_id`="g_test-1"
 
-and  `fitParam.modelPath`="${modelPath}"
+and  `fitParam.modelPath`="${HOME}/${modelPath}"
 
 and `systemParam.pythonPath`="python"
 and `systemParam.pythonVer`="2.7"

--- a/streamingpro-mlsql/src/test/scala/streaming/core/PythonMLSpec2.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/core/PythonMLSpec2.scala
@@ -38,7 +38,7 @@ class PythonMLSpec2 extends BasicSparkOperation with SpecFunctions with BasicMLS
 
       ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("python-alg-batch-predict"), Map(
         "pythonScriptPath" -> "/tmp/sklearn-user-predict-script.py",
-        "modelPath" -> "/tmp/william/pa_model_k"
+        "modelPath" -> "/pa_model_k"
       )), sq)
 
 


### PR DESCRIPTION
```sql
train data as PythonAlgBP.`${path}`
where
pythonScriptPath="${pythonScriptPath}"

and `kafkaParam.bootstrap.servers`="127.0.0.1:9092"
and `kafkaParam.topic`="test"
and `kafkaParam.group_id`="g_test-1"

and  `fitParam.modelPath`="${HOME}/${modelPath}"

and `systemParam.pythonPath`="python"
and `systemParam.pythonVer`="2.7"
;
```
StreamingPro支持支持主目录概念。但是之前只在特定path中生效，但比如在参数里，需要些全路径。现在可以使用${HOME}。