### PR TITLE
简化了udf函数创建

### DIFF
--- a/streamingpro-commons/src/main/java/streaming/common/SourceCodeCompiler.scala
+++ b/streamingpro-commons/src/main/java/streaming/common/SourceCodeCompiler.scala
@@ -1,14 +1,16 @@
 package streaming.common
 
 import javax.tools._
+
 import scala.collection.JavaConversions._
 import com.google.common.cache.{CacheBuilder, CacheLoader}
+import streaming.log.Logging
 
 
 /**
   * Created by allwefantasy on 27/8/2018.
   */
-object SourceCodeCompiler {
+object SourceCodeCompiler extends Logging {
   private val scriptCache = CacheBuilder.newBuilder()
     .maximumSize(10000)
     .build(
@@ -17,6 +19,7 @@ object SourceCodeCompiler {
           val startTime = System.nanoTime()
           val res = compileScala(prepareScala(scriptCacheKey.code, scriptCacheKey.className))
           def timeMs: Double = (System.nanoTime() - startTime).toDouble / 1000000
+          logInfo(s"generate udf time:${timeMs}")
           res
         }
       })

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/ScalaScriptUDF.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/ScalaScriptUDF.scala
@@ -21,11 +21,13 @@ class ScalaScriptUDF extends SQLAlg with MllibFunctions with Functions {
    */
   override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
     val res = sparkSession.table(path).head().getString(0)
-    require(params.contains("className"), "className is required")
-    val className = params("className")
     val methodName = params.get("methodName")
     require(params.contains("methodName"), "methodName is required")
-    val (func, returnType) = ScalaSourceUDF(res, className, methodName)
+    val (func, returnType) = if (params.contains("className")) {
+      ScalaSourceUDF(res, params("className"), methodName)
+    } else {
+      ScalaSourceUDF(res, methodName)
+    }
     UDFManager.register(sparkSession, methodName.get, (e: Seq[Expression]) => ScalaUDF(func, returnType, e))
   }
 

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/ScalaScriptUDF.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/ScalaScriptUDF.scala
@@ -21,17 +21,18 @@ class ScalaScriptUDF extends SQLAlg with MllibFunctions with Functions {
    */
   override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
     val res = sparkSession.table(path).head().getString(0)
-    val methodName = params.get("methodName")
-    require(params.contains("methodName"), "methodName is required")
+
     val (func, returnType) = if (params.contains("className")) {
-      ScalaSourceUDF(res, params("className"), methodName)
+      ScalaSourceUDF(res, params("className"), params.get("methodName"))
     } else {
-      ScalaSourceUDF(res, methodName)
+      ScalaSourceUDF(res, params.get("methodName"))
     }
-    UDFManager.register(sparkSession, methodName.get, (e: Seq[Expression]) => ScalaUDF(func, returnType, e))
+    (e: Seq[Expression]) => ScalaUDF(func, returnType, e)
   }
 
   override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {
+    val func = _model.asInstanceOf[(Seq[Expression]) => ScalaUDF]
+    UDFManager.register(sparkSession, name, func)
     null
   }
 }

--- a/streamingpro-mlsql/src/test/scala/streaming/core/DslSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/core/DslSpec.scala
@@ -425,6 +425,38 @@ class DslSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConf
       assume(res == 2)
       res = spark.sql("select plusFun(1,1)").collect().head.get(0)
       assume(res == 2)
+
+      ScriptSQLExec.parse(
+        """
+          |/*
+          |  MLSQL脚本完成UDF注册示例
+          |*/
+          |
+          |-- 填写script脚本
+          |set plusFun='''
+          |def apply(a:Double,b:Double)={
+          |   a + b
+          |}
+          |''';
+          |
+          |--加载脚本
+          |load script.`plusFun` as scriptTable;
+          |--注册为UDF函数 名称为plusFun
+          |register ScalaScriptUDF.`scriptTable` as plusFun
+          |;
+          |set data='''
+          |{"a":1}
+          |{"a":1}
+          |{"a":1}
+          |{"a":1}
+          |''';
+          |load jsonStr.`data` as dataTable;
+          |-- 使用plusFun
+          |select plusFun(1,1) as res from dataTable as output;
+        """.stripMargin, sq)
+
+      res = spark.sql("select plusFun(1,1)").collect().head.get(0)
+      assume(res == 2)
     }
 
 


### PR DESCRIPTION
```sql 
/*
  MLSQL脚本完成UDF注册示例
*/

-- 填写script脚本
set plusFun='''
def plusFun(a:Double,b:Double)={
   a + b
}
''';

--加载脚本
load script.`plusFun` as scriptTable;
--注册为UDF函数 名称为plusFun
register ScalaScriptUDF.`scriptTable` as plusFun options
and methodName="plusFun"
;
set data='''
{"a":1}
{"a":1}
{"a":1}
{"a":1}
''';
load jsonStr.`data` as dataTable;
-- 使用plusFun
select plusFun(1,1) as res from dataTable as output;
```

或者

```sql
/*
  MLSQL脚本完成UDF注册示例
*/

-- 填写script脚本
set plusFun='''
class PlusFun{
  def plusFun(a:Double,b:Double)={
   a + b
  }
}
''';

--加载脚本
load script.`plusFun` as scriptTable;
--注册为UDF函数 名称为plusFun
register ScalaScriptUDF.`scriptTable` as plusFun options
className="PlusFun"
and methodName="plusFun"
;

-- 使用plusFun
select plusFun(1,1) as res as output;
```

或者 

```sql
/*
  MLSQL脚本完成UDF注册示例
*/

-- 填写script脚本
set plusFun='''
def apply(a:Double,b:Double)={
   a + b
}
''';

--加载脚本
load script.`plusFun` as scriptTable;
--注册为UDF函数 名称为plusFun
register ScalaScriptUDF.`scriptTable` as plusFun
;
set data='''
{"a":1}
{"a":1}
{"a":1}
{"a":1}
''';
load jsonStr.`data` as dataTable;
-- 使用plusFun
select plusFun(1,1) as res from dataTable as output;
```