### PR TITLE
[mlsql][add] 添加批量预测模块SQLBatchPythonAlg

### DIFF
--- a/streamingpro-mlsql/src/main/java/org/apache/spark/ml/feature/PythonBatchPredictDataSchema.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/ml/feature/PythonBatchPredictDataSchema.scala
@@ -1,0 +1,24 @@
+package org.apache.spark.ml.feature
+
+import org.apache.spark.ml.linalg.MatrixUDT
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.{ArrayType, StructField, StructType}
+
+/**
+ * Created by fchen on 2018/8/26.
+ */
+object PythonBatchPredictDataSchema {
+  /**
+   * 数据结构, size = batchSize
+   * {
+   *   originalDatas: indexSeq
+   *   combineFeatures: Matrix
+   * }
+   */
+  val newSchema: (DataFrame) => StructType = df => {
+    StructType(Seq(
+      StructField("originalData", ArrayType(df.schema)),
+      StructField("newFeature", new MatrixUDT())
+    ))
+  }
+}

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -89,7 +89,8 @@ object MLMapping {
     "Map" -> "streaming.dsl.mmlib.algs.SQLMap",
     "PythonAlgBP" -> "streaming.dsl.mmlib.algs.SQLPythonAlgBatchPrediction",
     "ScalaScriptUDF" -> "streaming.dsl.mmlib.algs.ScriptUDF",
-    "ScriptUDF" -> "streaming.dsl.mmlib.algs.ScriptUDF"
+    "ScriptUDF" -> "streaming.dsl.mmlib.algs.ScriptUDF",
+    "BatchPythonAlg" -> "streaming.dsl.mmlib.algs.SQLBatchPythonAlg"
   )
 
   def findAlg(name: String) = {

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLBatchPythonAlg.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLBatchPythonAlg.scala
@@ -1,0 +1,186 @@
+package streaming.dsl.mmlib.algs
+
+import java.nio.file.{Files, Paths}
+import java.util.{ArrayList, HashMap, UUID, Map => JMap}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.WrappedArray
+
+import org.apache.spark.{APIDeployPythonRunnerEnv, TaskContext}
+import org.apache.spark.api.python.WowPythonRunner
+import org.apache.spark.ml.feature.PythonBatchPredictDataSchema
+import org.apache.spark.ml.linalg.{Matrices, Matrix, Vector}
+import org.apache.spark.ml.linalg.SQLDataTypes.{MatrixType, VectorType}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types._
+import org.apache.spark.util.{ExternalCommandRunner, MatrixSerDer, ObjPickle}
+import streaming.core.strategy.platform.PlatformManager
+import streaming.dsl.mmlib.SQLAlg
+
+/**
+ * Created by fchen on 2018/8/22.
+ */
+class SQLBatchPythonAlg extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val spark = df.sparkSession
+    val pythonAlg = new SQLPythonAlg()
+    val model = pythonAlg.load(spark, path, params)
+    val (modelsTemp, metasTemp, trainParams, selectedFitParam) =
+      model.asInstanceOf[(Seq[String], Seq[Map[String, String]], Map[String, String], Map[String, Any])]
+    val batchSize = params.getOrElse("batchSize", "10").toInt
+    val inputCol = params.getOrElse("inputCol", "")
+    require(inputCol != null && inputCol != "", s"inputCol in ${getClass} module should be configed!")
+    val batchPredictFun = params.getOrElse("predictFun", UUID.randomUUID().toString.replaceAll("-", ""))
+    val predictLabelColumnName = params.getOrElse("predictCol", "predict_label")
+    val predictTableName = params.getOrElse("predictTable", "")
+    require(
+      predictTableName != null && predictTableName != "",
+      s"predictTable in ${getClass} module should be configed!"
+    )
+
+    val schema = PythonBatchPredictDataSchema.newSchema(df)
+
+    val rdd = df.rdd.mapPartitions(it => {
+      var list = List.empty[List[Row]]
+      var tmpList = List.empty[Row]
+      var batchCount = 0
+      while (it.hasNext) {
+        val e = it.next()
+        if (batchCount == batchSize) {
+          list +:= tmpList
+          batchCount = 0
+          tmpList = List.empty[Row]
+        } else {
+          tmpList +:= e
+          batchCount += 1
+        }
+      }
+      if (batchCount != batchSize) {
+        list +:= tmpList
+      }
+      list.map(x => {
+        Row.fromSeq(Seq(x, SQLBatchPythonAlg.createNewFeatures(x, inputCol)))
+      }).iterator
+    })
+
+    val systemParam = mapParams("systemParam", params)
+    val pythonPath = systemParam.getOrElse("pythonPath", "python")
+    val pythonVer = systemParam.getOrElse("pythonVer", "2.7")
+    val kafkaParam = mapParams("kafkaParam", trainParams)
+
+    // load python script
+    val userPythonScript = SQLPythonFunc.findPythonPredictScript(spark, params, "")
+
+    val maps = new HashMap[String, JMap[String, _]]()
+    val item = new HashMap[String, String]()
+    item.put("funcPath", "/tmp/" + System.currentTimeMillis())
+    maps.put("systemParam", item)
+    maps.put("internalSystemParam", selectedFitParam.asJava)
+
+    val res = ExternalCommandRunner.run(Seq(pythonPath, userPythonScript.fileName),
+      maps,
+      MapType(StringType, MapType(StringType, StringType)),
+      userPythonScript.fileContent,
+      userPythonScript.fileName, modelPath = null, recordLog = SQLPythonFunc.recordAnyLog(kafkaParam)
+    )
+    res.foreach(f => f)
+    val command = Files.readAllBytes(Paths.get(item.get("funcPath")))
+    val runtimeParams = PlatformManager.getRuntime.params.asScala.toMap
+
+    // registe batch predict python function
+
+    val recordLog = SQLPythonFunc.recordAnyLog(Map[String, String]())
+    val models = spark.sparkContext.broadcast(modelsTemp)
+    val f = (m: Matrix, modelPath: String) => {
+      val modelRow = InternalRow.fromSeq(Seq(SQLPythonFunc.getLocalTempModelPath(modelPath)))
+      val trainParamsRow = InternalRow.fromSeq(Seq(ArrayBasedMapData(params)))
+      val v_ser = ObjPickle.pickleInternalRow(Seq(MatrixSerDer.serialize(m)).toIterator, MatrixSerDer.matrixSchema())
+      val v_ser2 = ObjPickle.pickleInternalRow(Seq(modelRow).toIterator, StructType(Seq(StructField("modelPath", StringType))))
+      var v_ser3 = v_ser ++ v_ser2
+//      if (enableCopyTrainParamsToPython) {
+//        val v_ser4 = pickleInternalRow(Seq(trainParamsRow).toIterator, StructType(Seq(StructField("trainParams", MapType(StringType, StringType)))))
+//        v_ser3 = v_ser3 ++ v_ser4
+//      }
+
+//      if (TaskContext.get() == null) {
+//        APIDeployPythonRunnerEnv.setTaskContext(APIDeployPythonRunnerEnv.createTaskContext())
+//      }
+      val iter = WowPythonRunner.run(
+        pythonPath, pythonVer, command, v_ser3, TaskContext.get().partitionId(), Array(), runtimeParams, recordLog
+      )
+      val a = iter.next()
+      val predictValue = MatrixSerDer.deserialize(ObjPickle.unpickle(a).asInstanceOf[java.util.ArrayList[Object]].get(0))
+      predictValue
+    }
+
+    val f2 = (m: Matrix) => {
+      models.value.map { modelPath =>
+        f(m, modelPath)
+      }.head
+    }
+
+    val func = UserDefinedFunction(f2, MatrixType, Some(Seq(MatrixType)))
+    spark.udf.register(batchPredictFun, func)
+
+    // temp batch predict column name
+    val tmpPredColName = UUID.randomUUID().toString.replaceAll("-", "")
+    val pdf = spark.createDataFrame(rdd, schema)
+      .selectExpr(s"${batchPredictFun}(newFeature) as ${tmpPredColName}", "originalData")
+
+    //    pdf.write.mode(SaveMode.Overwrite).json("/tmp/result")
+
+    val prdd = pdf.rdd.mapPartitions(it => {
+      var list = List.empty[Row]
+      while (it.hasNext) {
+        val e = it.next()
+        val originalData = e.getAs[WrappedArray[Row]]("originalData")
+        val newFeature = e.getAs[Matrix](tmpPredColName).rowIter.toList
+        val size = originalData.size
+        (0 until size).map(index => {
+          val od = originalData(index)
+          val pd = newFeature(index)
+          list +:= Row.fromSeq(od.toSeq ++ Seq(pd))
+        })
+      }
+      list.iterator
+    })
+    val pschema = df.schema.add(predictLabelColumnName, VectorType)
+//    spark.createDataFrame(prdd, pschema).write.mode(SaveMode.Overwrite).json("/tmp/fresult")
+    spark.createDataFrame(prdd, pschema).createOrReplaceTempView(predictTableName)
+
+  }
+
+  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
+    throw new UnsupportedOperationException(s"${getClass.getSimpleName} unsupport load function")
+  }
+
+  override def predict(sparkSession: SparkSession,
+                       _model: Any,
+                       name: String,
+                       params: Map[String, String]): UserDefinedFunction = {
+    throw new UnsupportedOperationException(s"${getClass.getSimpleName} unsupport predict function")
+
+  }
+}
+
+object SQLBatchPythonAlg {
+  private def createNewFeatures(list: List[Row], inputCol: String): Matrix = {
+    val numRows = list.size
+    val numCols = list.head.getAs[Vector](inputCol).size
+    val values = new ArrayList[Double](numCols * numRows)
+
+    val vectorArray = list.map(r => {
+      r.getAs[Vector](inputCol).toArray
+    })
+    for (i <- (0 until numCols)) {
+      for (j <- (0 until numRows)) {
+        values.add(vectorArray(j)(i))
+      }
+    }
+    Matrices.dense(numRows, numCols, values.asScala.toArray).toSparse
+  }
+}
+


### PR DESCRIPTION
在`PythonAlg`模块训练完成后，可以利用`BatchPythonAlg`进行批量预测
预测`MLSQL`脚本
```sql
set dataPath2 = "/path/to/train/data";
load json.`${dataPath}` as transform_scale_data;

-- train configuration
set kafkaDomain="kafka31:9092";
set sklearnPredictPath="/Users/fchen/tmp/streamingpro/python/shunzi/predict2.py";
-- PythonAlg训练的模型路径
set modelPath="/tmp/user_recgn/models/IsolationForest_v2";

train transform_scale_data as BatchPythonAlg.`${modelPath}` where
pythonScriptPath="${sklearnPredictPath}"
and `systemParam.pythonPath`="/usr/local/share/anaconda3/envs/mlsql-2.2.0/bin/python"
and `systemParam.pythonVer`="3.6"
and inputCol = "features2"
-- 每次喂给模型条数
and batchSize = "1000"
-- 批量预测udf名
and predictFun = "fchen_predict"
-- 预测结果的列名
and predictCol = "predict_vector"
-- 预测的零时表名
and predictTable = "fchen_result"
and algIndex="0";

select vec_array(predict_vector)[0] as predict_label,* from fchen_result
as fchen_result1;

save overwrite fchen_result1 as json.`/tmp/fchen_result`;
```

`python`预测脚本

```python
from __future__ import absolute_import
from pyspark.ml.linalg import MatrixUDT, Matrix, DenseMatrix
import pickle
import os

run_for_test = False
if run_for_test:
    import mlsql.python_fun
else:
    import python_fun


def predict(index, s):
    items = [i for i in s]
    modelPath = pickle.loads(items[1])[0] + "/model.pkl"

    if not hasattr(os, "mlsql_models"):
        setattr(os, "mlsql_models", {})
    if modelPath not in os.mlsql_models:
        print("Load sklearn model %s" % modelPath)
        os.mlsql_models[modelPath] = pickle.load(open(modelPath, "rb"))

    model = os.mlsql_models[modelPath]
    rawMatrix = pickle.loads(items[0])
    feature = MatrixUDT().deserialize(rawMatrix)
    y = model.predict(feature.toArray())
    row_num = len(y)
    dm = DenseMatrix(row_num, 1, y)
    return [MatrixUDT().serialize(dm)]


python_fun.udf(predict)
```