### PR TITLE
扩展了rest接口，同时保证http include 支持更友好的使用方式

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/IncludeAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/IncludeAdaptor.scala
@@ -39,7 +39,8 @@ class IncludeAdaptor(scriptSQLExecListener: ScriptSQLExecListener, preProcessLis
     if (!alg.skipPathPrefix) {
       path = withPathPrefix(scriptSQLExecListener.pathPrefix(None), path)
     }
-    val content = alg.fetchSource(scriptSQLExecListener.sparkSession, path, option)
+
+    val content = alg.fetchSource(scriptSQLExecListener.sparkSession, path, Map("owner" -> ScriptSQLExec.context().owner) ++ option)
     val originIncludeText = currentText(ctx)
     preProcessListener.addInclude(originIncludeText, content)
   }

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/includes/HTTPIncludeSource.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/includes/HTTPIncludeSource.scala
@@ -2,7 +2,7 @@ package streaming.dsl.mmlib.algs.includes
 
 import org.apache.spark.sql.SparkSession
 import streaming.crawler.HttpClientCrawler
-import streaming.dsl.IncludeSource
+import streaming.dsl.{IncludeSource, ScriptSQLExec}
 import streaming.log.Logging
 
 /**
@@ -11,11 +11,13 @@ import streaming.log.Logging
 class HTTPIncludeSource extends IncludeSource with Logging {
   override def fetchSource(sparkSession: SparkSession, path: String, options: Map[String, String]): String = {
 
+    val context = ScriptSQLExec.context()
+
     var params = scala.collection.mutable.HashMap(
       "path" -> path
     )
-    if (options.contains("__owner__")) {
-      params += ("owner" -> options("owner"))
+    if (context.owner != null) {
+      params += ("owner" -> context.owner)
     }
 
     options.filter(f => f._1.startsWith("param.")).map(f => (f._1.substring("param.".length), f._2)).foreach { f =>
@@ -23,7 +25,13 @@ class HTTPIncludeSource extends IncludeSource with Logging {
     }
 
     val method = options.getOrElse("method", "get")
-    val fetch_url = options.getOrElse("__default_fetch_url__", path)
+    val fetch_url = context.userDefinedParam.getOrElse("__default__include_fetch_url__", path)
+    val projectName = context.userDefinedParam.getOrElse("__default__include_project_name__", null)
+
+    if (projectName != null) {
+      params += ("projectName" -> projectName)
+    }
+
     logInfo(s"""HTTPIncludeSource URL: ${fetch_url}  PARAMS:${params.map(f => s"${f._1}=>${f._2}").mkString(";")}""")
     HttpClientCrawler.requestByMethod(fetch_url, method, params.toMap)
   }


### PR DESCRIPTION
include http语法使用示例：

正常使用状态：
```sql
include http.`http://abc.log` options 
`param.a`="coo" 
and `param.b`="wow";
```
其中param. 开头的参数会被提交给http接口。非param开头的，则会被该模块作为配置参数识别。

如果在访问streamingpro时，传递了如下参数：

```
context.__default__include_fetch_url__=http://....
context.__default__include_project_name__=analyser....
```

则可以这么使用：

```sql
include http.`function.dir1.scriptfile1` ;
```

http源会自动使用__default__include_fetch_url__作为请求地址，同时将__default__include_project_name__作为主目录传递给后端的，同时将owner也会传递给后端。

如果要实现成

```
include function.`dir1.scriptfile1`;
```
则添加自己的实现即可，方式是完全一样的。
