### PR TITLE
支持scala udaf script

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/IncludeAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/IncludeAdaptor.scala
@@ -40,7 +40,7 @@ class IncludeAdaptor(scriptSQLExecListener: ScriptSQLExecListener, preProcessLis
       path = withPathPrefix(scriptSQLExecListener.pathPrefix(None), path)
     }
 
-    val content = alg.fetchSource(scriptSQLExecListener.sparkSession, path, Map("owner" -> ScriptSQLExec.context().owner) ++ option)
+    val content = alg.fetchSource(scriptSQLExecListener.sparkSession, path, option)
     val originIncludeText = currentText(ctx)
     preProcessListener.addInclude(originIncludeText, content)
   }

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/ScriptUDF.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/ScriptUDF.scala
@@ -1,12 +1,12 @@
 package streaming.dsl.mmlib.algs
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, ScalaUDF}
+import org.apache.spark.sql.execution.aggregate.ScalaUDAF
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.udf.UDFManager
 import streaming.dsl.mmlib.SQLAlg
-import streaming.udf.ScalaSourceUDF
-import streaming.udf.PythonSourceUDF
+import streaming.udf.{PythonSourceUDF, ScalaSourceUDAF, ScalaSourceUDF}
 
 /**
   * Created by allwefantasy on 27/8/2018.
@@ -22,23 +22,44 @@ class ScriptUDF extends SQLAlg with MllibFunctions with Functions {
    */
   override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
     val res = sparkSession.table(path).head().getString(0)
-    val lang = params.getOrElse("lang", "scala")
-    val (func, returnType) = lang match {
-      case "python" =>
-        if (params.contains("className")) {
-          PythonSourceUDF(res, params("className"), params.get("methodName"), params("dataType"))
-        } else {
-          PythonSourceUDF(res, params.get("methodName"), params("dataType"))
-        }
 
-      case _ =>
-        if (params.contains("className")) {
-          ScalaSourceUDF(res, params("className"), params.get("methodName"))
-        } else {
-          ScalaSourceUDF(res, params.get("methodName"))
-        }
+    val lang = params.getOrElse("lang", "scala")
+    val udfType = params.getOrElse("udfType", "udf")
+
+    val udf = () => {
+      val (func, returnType) = lang match {
+        case "python" =>
+          if (params.contains("className")) {
+            PythonSourceUDF(res, params("className"), params.get("methodName"), params("dataType"))
+          } else {
+            PythonSourceUDF(res, params.get("methodName"), params("dataType"))
+          }
+
+        case _ =>
+          if (params.contains("className")) {
+            ScalaSourceUDF(res, params("className"), params.get("methodName"))
+          } else {
+            ScalaSourceUDF(res, params.get("methodName"))
+          }
+      }
+      (e: Seq[Expression]) => ScalaUDF(func, returnType, e)
     }
-    (e: Seq[Expression]) => ScalaUDF(func, returnType, e)
+
+    val udaf = () => {
+      val func = lang match {
+        case "python" =>
+          null
+
+        case _ =>
+          ScalaSourceUDAF(res, params("className"))
+      }
+      (e: Seq[Expression]) => ScalaUDAF(e, func)
+    }
+
+    udfType match {
+      case "udaf" => udaf()
+      case _ => udf()
+    }
   }
 
   override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {

--- a/streamingpro-mlsql/src/main/java/streaming/udf/ScalaSourceUDAF.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/udf/ScalaSourceUDAF.scala
@@ -1,0 +1,73 @@
+package streaming.udf
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
+import org.apache.spark.sql.types.{DataType, StructType}
+import streaming.common.{ScriptCacheKey, SourceCodeCompiler}
+
+import scala.reflect.ClassTag
+
+object ScalaSourceUDAF {
+  def apply(src: String, className: String): UserDefinedAggregateFunction = {
+    generateAggregateFunction(src, className)
+  }
+
+  private def generateAggregateFunction(src: String, className: String): UserDefinedAggregateFunction = {
+    new UserDefinedAggregateFunction with Serializable {
+
+      @transient val clazzUsingInDriver = SourceCodeCompiler.execute(ScriptCacheKey(src, className)).asInstanceOf[Class[_]]
+      @transient val instanceUsingInDriver = SourceCodeCompiler.newInstance(clazzUsingInDriver)
+
+      lazy val clazzUsingInExecutor = SourceCodeCompiler.execute(ScriptCacheKey(src, className)).asInstanceOf[Class[_]]
+      lazy val instanceUsingInExecutor = SourceCodeCompiler.newInstance(clazzUsingInExecutor)
+
+      def invokeMethod[T: ClassTag](clazz: Class[_], instance: Any, method: String): T = {
+        SourceCodeCompiler.getMethod(clazz, method).invoke(instance).asInstanceOf[T]
+      }
+
+      val _inputSchema = invokeMethod[StructType](clazzUsingInDriver, instanceUsingInDriver, "inputSchema")
+      val _dataType = invokeMethod[DataType](clazzUsingInDriver, instanceUsingInDriver, "dataType")
+      val _bufferSchema = invokeMethod[StructType](clazzUsingInDriver, instanceUsingInDriver, "bufferSchema")
+      val _deterministic = invokeMethod[Boolean](clazzUsingInDriver, instanceUsingInDriver, "deterministic")
+
+      override def inputSchema: StructType = {
+        _inputSchema
+      }
+
+      override def dataType: DataType = {
+        _dataType
+      }
+
+      override def bufferSchema: StructType = {
+        _bufferSchema
+      }
+
+      override def deterministic: Boolean = {
+        _deterministic
+      }
+
+      lazy val _update = SourceCodeCompiler.getMethod(clazzUsingInExecutor, "update")
+      lazy val _merge = SourceCodeCompiler.getMethod(clazzUsingInExecutor, "merge")
+      lazy val _initialize = SourceCodeCompiler.getMethod(clazzUsingInExecutor, "initialize")
+      lazy val _evaluate = SourceCodeCompiler.getMethod(clazzUsingInExecutor, "evaluate")
+
+      override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+        _update.invoke(instanceUsingInExecutor, buffer, input)
+      }
+
+      override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+        _merge.invoke(instanceUsingInExecutor, buffer1, buffer2)
+      }
+
+      override def initialize(buffer: MutableAggregationBuffer): Unit = {
+        _initialize.invoke(instanceUsingInExecutor, buffer)
+      }
+
+      override def evaluate(buffer: Row): Any = {
+        _evaluate.invoke(instanceUsingInExecutor, buffer)
+      }
+
+
+    }
+  }
+}


### PR DESCRIPTION
```sql
set plusFun='''
import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
import org.apache.spark.sql.types._
import org.apache.spark.sql.Row
class SumAggregation extends UserDefinedAggregateFunction with Serializable{
    def inputSchema: StructType = new StructType().add("a", LongType)
    def bufferSchema: StructType =  new StructType().add("total", LongType)
    def dataType: DataType = LongType
    def deterministic: Boolean = true
    def initialize(buffer: MutableAggregationBuffer): Unit = {
      buffer.update(0, 0l)
    }
    def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
      val sum   = buffer.getLong(0)
      val newitem = input.getLong(0)
      buffer.update(0, sum + newitem)
    }
    def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
      buffer1.update(0, buffer1.getLong(0) + buffer2.getLong(0))
    }
    def evaluate(buffer: Row): Any = {
      buffer.getLong(0)
    }
}
''';


--加载脚本
load script.`plusFun` as scriptTable;
--注册为UDF函数 名称为plusFun
register ScriptUDF.`scriptTable` as plusFun options
className="SumAggregation"
and udfType="udaf"
;

set data='''
{"a":1}
{"a":1}
{"a":1}
{"a":1}
''';
load jsonStr.`data` as dataTable;

-- 使用plusFun
select a,plusFun(a) as res from dataTable group by a as output;
```