### PR TITLE
[DSL][add] dsl适配关键字大小写

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/CaseChangingCharStream.java
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/CaseChangingCharStream.java
@@ -1,0 +1,90 @@
+package streaming.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.misc.Interval;
+
+/**
+ * Created by fchen on 2018/9/6.
+ */
+public class CaseChangingCharStream implements CharStream {
+
+  final CharStream stream;
+  final boolean upper;
+
+  /**
+   * Constructs a new CaseChangingCharStream wrapping the given {@link CharStream} forcing
+   * all characters to upper case or lower case.
+   * @param stream The stream to wrap.
+   * @param upper If true force each symbol to upper case, otherwise force to lower.
+   */
+  public CaseChangingCharStream(CharStream stream, boolean upper) {
+    this.stream = stream;
+    this.upper = upper;
+  }
+
+  public CaseChangingCharStream(CharStream stream) {
+    this.stream = stream;
+    this.upper = true;
+  }
+
+  public CaseChangingCharStream(String string) throws IOException {
+    ByteArrayInputStream bais = new ByteArrayInputStream(string.getBytes());
+    this.stream = CharStreams.fromStream(bais);
+    this.upper = false;
+  }
+  @Override
+  public String getText(Interval interval) {
+    return stream.getText(interval);
+  }
+
+  @Override
+  public void consume() {
+    stream.consume();
+  }
+
+  @Override
+  public int LA(int i) {
+    int c = stream.LA(i);
+    if (c <= 0) {
+      return c;
+    }
+    if (upper) {
+      return Character.toUpperCase(c);
+    }
+    return Character.toLowerCase(c);
+  }
+
+  @Override
+  public int mark() {
+    return stream.mark();
+  }
+
+  @Override
+  public void release(int marker) {
+    stream.release(marker);
+  }
+
+  @Override
+  public int index() {
+    return stream.index();
+  }
+
+  @Override
+  public void seek(int index) {
+    stream.seek(index);
+  }
+
+  @Override
+  public int size() {
+    return stream.size();
+  }
+
+  @Override
+  public String getSourceName() {
+    return stream.getSourceName();
+  }
+}

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/ScriptSQLExec.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/ScriptSQLExec.scala
@@ -72,7 +72,7 @@ object ScriptSQLExec extends Logging with WowLog {
   }
 
   def _parse(input: String, listener: DSLSQLListener) = {
-    val loadLexer = new DSLSQLLexer(new ANTLRInputStream(input))
+    val loadLexer = new DSLSQLLexer(new CaseChangingCharStream(input))
     val tokens = new CommonTokenStream(loadLexer)
     val parser = new DSLSQLParser(tokens)
     parser.addErrorListener(new BaseErrorListener {


### PR DESCRIPTION
`dsl`支持关键字大小写不敏感，即：
```sql
loAd json.`/tmp/a.json` aS fchen_test;
```
等同于
```
load json.`/tmp/a.json` as fchen_test;
```

注意：

通过`streaming.dsl.parser.SqlContext.getText()`获取的关键字仍然是大小写敏感的，例如上述`loAd`
