### PR TITLE
[MLSQL][add] 添加MapValues数据处理模块，针对大数据量的字典情况，数据量小可以使用set语法

### DIFF
--- a/docs/mlsql-data-processing-model.md
+++ b/docs/mlsql-data-processing-model.md
@@ -20,6 +20,7 @@
   - [Word2ArrayInPlace](#word2arrayinplace)
   - [WaterMarkInPlace](#watermarkinplace)
   - [SendMessage](#sendmessage)
+  - [MapValues](#mapvalues)
 - [**低阶数据预处理模型**](#低阶特定小功能点数据预处理模型)
   - [Word2vec](#word2vec)
   - [StringIndex](#stringindex)
@@ -776,6 +777,39 @@ and to = "chenfu@dxy.cn"
 and subject = "这是邮件标题"
 -- 邮件服务器地址
 and smtpHost = "${smtp-ip-address}";
+```
+
+### MapValues
+
+字典映射模块
+
+例子:
+
+```sql
+set json = '''
+{"word": "unk", "value": [0.0, 0.0, 0.0, 0.0]}
+{"word": "a", "value": [1.0, 0.0, 0.0, 0.0]}
+{"word": "b", "value": [0.0, 1.0, 0.0, 0.0]}
+{"word": "c", "value": [0.0, 0.0, 1.0, 0.0]}
+{"word": "d", "value": [0.0, 0.0, 0.0, 1.0]}
+''';
+load jsonStr.`json` as input;
+
+select word, vec_dense(value) as feature from input as train_table;
+
+train train_table as MapValues.`/tmp/mapvalues`
+where inputCol = "word"
+and outputCol = "feature"
+and mapMissingTo = "unk";
+
+register MapValues.`/tmp/mapvalues` as fchen;
+
+set json2 = '''
+{"x": "abc"}
+{"x": "a"}
+''';
+load jsonStr.`json2` as input2;
+select fchen(x) from input2 as input3;
 ```
 
 ## 低阶（特定小功能点）数据预处理模型

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/TrainAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/TrainAdaptor.scala
@@ -90,6 +90,7 @@ object MLMapping {
     "PythonAlgBP" -> "streaming.dsl.mmlib.algs.SQLPythonAlgBatchPrediction",
     "ScalaScriptUDF" -> "streaming.dsl.mmlib.algs.ScriptUDF",
     "ScriptUDF" -> "streaming.dsl.mmlib.algs.ScriptUDF",
+    "MapValues" -> "streaming.dsl.mmlib.algs.SQLMapValues",
     "BatchPythonAlg" -> "streaming.dsl.mmlib.algs.SQLBatchPythonAlg"
   )
 

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLMapValues.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLMapValues.scala
@@ -1,0 +1,91 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.{ArrayType, StringType, StructType}
+import _root_.streaming.dsl.mmlib.SQLAlg
+import _root_.streaming.dsl.mmlib.algs.meta.MapValuesMeta
+
+
+class SQLMapValues extends SQLAlg with Functions {
+  override def train(df: DataFrame, path: String, params: Map[String, String]): Unit = {
+    val spark = df.sparkSession
+    import spark.implicits._
+    val metaPath = MetaConst.getMetaPath(path)
+    val dataPath = MetaConst.getDataPath(path)
+    saveTraningParams(df.sparkSession, params + ("path" -> path), metaPath)
+    val inputCol = params.get("inputCol")
+    val outputCol = params.get("outputCol")
+    val mapMissingTo = params.get("mapMissingTo")
+    require(mapMissingTo.isDefined)
+    require(inputCol.isDefined, "inputCol should be configured!")
+    require(outputCol.isDefined, "outputCol should be configured!")
+
+    // validate mapMissingTo
+    val mapMissingToValue = df.filter(row => {
+      row.getAs[String](inputCol.get) == mapMissingTo.get
+    }).collect()
+
+    require(mapMissingToValue.size == 1, s"can't find or find multi ${mapMissingTo.get} in giving table!")
+
+    // save dictionary
+    val toSaveCols = Array(inputCol.get, outputCol.get)
+
+    df.select(toSaveCols.map(new Column(_)): _*)
+      .write
+      .mode(SaveMode.Overwrite)
+      .parquet(dataPath)
+
+    // save train metadata
+    val meta = MapValuesMeta(inputCol.get, outputCol.get, mapMissingTo.get)
+    spark.createDataFrame(Seq(meta))
+      .write
+      .mode(SaveMode.Overwrite)
+      .parquet(metaPath)
+
+  }
+
+  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
+
+    import sparkSession.implicits._
+
+    // load dictionary and train parameters.
+    val dataPath = MetaConst.getDataPath(path)
+
+    val dict = sparkSession.read.parquet(dataPath)
+
+    val metaPath = MetaConst.getMetaPath(path)
+
+    val meta = sparkSession.read.parquet(metaPath).as[MapValuesMeta].collect().head
+    (dict, meta)
+  }
+
+  override def predict(sparkSession: SparkSession,
+                       _model: Any,
+                       name: String,
+                       params: Map[String, String]): UserDefinedFunction = {
+    val (dict, meta) = _model.asInstanceOf[(DataFrame, MapValuesMeta)]
+
+    val outputDataType = dict.schema.fields.filter(st => meta.outputCol == st.name).head.dataType
+
+    val mapMissingToValue = dict.filter(row => {
+      row.getAs[String](meta.inputCol) == meta.mapMissingTo
+    }).collect()
+      .head
+      .getAs[Any](meta.outputCol)
+
+    val dictionary = dict.collect().map(f => {
+      val key = f.getAs[String](meta.inputCol)
+      val value = f.getAs[Any](meta.outputCol)
+      (key, value)
+    }).toMap
+
+    val defaultvalue = sparkSession.sparkContext.broadcast(mapMissingToValue)
+    val dictbc = sparkSession.sparkContext.broadcast(dictionary)
+
+    val f = (key: String) => {
+      dictbc.value.getOrElse(key, defaultvalue.value)
+    }
+    UserDefinedFunction(f, outputDataType, Some(Seq(StringType)))
+  }
+}

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/meta/Meta.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/meta/Meta.scala
@@ -2,6 +2,7 @@ package streaming.dsl.mmlib.algs.meta
 
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.DataType
 import streaming.dsl.mmlib.algs.DiscretizerTrainData
 
 /**
@@ -25,3 +26,8 @@ case class StandardScalerValueMeta(fieldName: String, mean: Array[Double], std: 
 case class DiscretizerMeta(params: Array[DiscretizerTrainData], discretizerFunc: Seq[Double] => Seq[Double])
 
 case class Word2ArrayMeta(trainParams: Map[String, String], words: Set[String])
+
+case class MapValuesMeta(
+    inputCol: String,
+    outputCol: String,
+    mapMissingTo: String)


### PR DESCRIPTION
```sql
set json = '''
{"word": "unk", "value": [0.0, 0.0, 0.0, 0.0]}
{"word": "a", "value": [1.0, 0.0, 0.0, 0.0]}
{"word": "b", "value": [0.0, 1.0, 0.0, 0.0]}
{"word": "c", "value": [0.0, 0.0, 1.0, 0.0]}
{"word": "d", "value": [0.0, 0.0, 0.0, 1.0]}
''';
load jsonStr.`json` as input;

select word, vec_dense(value) as feature from input as train_table;

train train_table as MapValues.`/tmp/mapvalues`
where inputCol = "word"
and outputCol = "feature"
and mapMissingTo = "unk";

register MapValues.`/tmp/mapvalues` as fchen;

set json2 = '''
{"x": "abc"}
{"x": "a"}
''';
load jsonStr.`json2` as input2;
select fchen(x) from input2 as input3;
```