### PR TITLE
[Enhance] GBTs support

### DIFF
--- a/streamingpro-mlsql/src/test/scala/streaming/MLLibSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/MLLibSpec.scala
@@ -4,7 +4,7 @@ import org.apache.spark.streaming.BasicSparkOperation
 import streaming.core.strategy.platform.SparkRuntime
 import streaming.core.{BasicMLSQLConfig, SpecFunctions}
 import streaming.dsl.ScriptSQLExec
-import streaming.dsl.mmlib.algs.{SQLKMeans, SQLRandomForest}
+import streaming.dsl.mmlib.algs.{SQLGBTs, SQLKMeans, SQLRandomForest}
 
 /**
   * Created by allwefantasy on 13/9/2018.
@@ -47,6 +47,27 @@ class MLLibSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLCo
       ))
       val models = randomForest.load(spark, "/tmp/KMeans", Map("autoSelectByMetric" -> "silhouette"))
       val udf = randomForest.predict(spark, models, "jack", Map("autoSelectByMetric" -> "silhouette"))
+      spark.udf.register("jack", udf)
+      df.selectExpr("jack(features) as predict").show()
+    }
+  }
+
+  "GBTs" should "work fine" in {
+    copySampleLibsvmData
+    withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
+      implicit val spark = runtime.sparkSession
+      val randomForest = new SQLGBTs()
+      ScriptSQLExec.contextGetOrForTest()
+
+      val df = spark.read.format("libsvm").load("/tmp/william/sample_libsvm_data.txt")
+      df.createOrReplaceTempView("data")
+      randomForest.train(df, "/tmp/GBTs", Map(
+        "keepVersion" -> "true",
+        "evaluateTable" -> "data",
+        "fitParam.0.maxDepth" -> "2"
+      ))
+      val models = randomForest.load(spark, "/tmp/GBTs", Map("autoSelectByMetric" -> "f1"))
+      val udf = randomForest.predict(spark, models, "jack", Map("autoSelectByMetric" -> "f1"))
       spark.udf.register("jack", udf)
       df.selectExpr("jack(features) as predict").show()
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
We have already added many features to RandomForest [mlsql-mllib-randomfores-classfication](https://github.com/allwefantasy/streamingpro/blob/master/docs/en/mlsql-mllib-randomfores-classfication.md)
  e.g. version,multi-group-params train,auto evaluate.  Now We will try to port these features to other algs.

## How was this patch tested?

Unit tests: streaming.MLLibSpec

## Spark Core Compatibility

1. Spark 2.2.x
2. Spark 2.3.x
