### PR TITLE
python project support for SQLPythonAlg module

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLExternalPythonAlg.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLExternalPythonAlg.scala
@@ -41,6 +41,15 @@ class SQLExternalPythonAlg extends SQLPythonAlg {
       }
     }
 
+    // distribute python project
+
+    val loadPythonProject = params.contains("pythonProjectPath")
+    if (loadPythonProject) {
+      distributePythonProject(params).foreach(path => {
+        resourceParams += ("pythonProjectPath" -> path)
+      })
+    }
+
     (Seq(""), metasTemp, params, selectedFitParam + ("resource" -> resourceParams.asJava))
   }
 }

--- a/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/util/ExternalCommandRunner.scala
+++ b/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/util/ExternalCommandRunner.scala
@@ -115,12 +115,9 @@ object ExternalCommandRunner extends Logging {
         val err = proc.getErrorStream
 
         try {
-          for (line <- Source.fromInputStream(err)(encoding).getLines) {
-            // scalastyle:off println
-            logCallback("__python__:" + line)
-            errorBuffer += line
-            // scalastyle:on println
-          }
+          val errorLog = logBuilder(Source.fromInputStream(err)(encoding).getLines())
+          logCallback(errorLog)
+          System.err.println(errorLog)
         } catch {
           case t: Throwable =>
             childThreadException.set(t)
@@ -244,6 +241,15 @@ object ExternalCommandRunner extends Logging {
         }
       }
     }
+  }
+  def logBuilder(iterator: Iterator[String]): String = {
+    val builder = StringBuilder.newBuilder
+    while (iterator.hasNext) {
+      val line = iterator.next()
+      builder.append(s"__python__:$line")
+      builder.append("\n")
+    }
+    builder.toString
   }
 
 }

--- a/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/util/ExternalCommandRunner.scala
+++ b/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/util/ExternalCommandRunner.scala
@@ -115,7 +115,9 @@ object ExternalCommandRunner extends Logging {
         val err = proc.getErrorStream
 
         try {
-          logCallback(logBuilder(Source.fromInputStream(err)(encoding).getLines()))
+          val errorLog = logBuilder(Source.fromInputStream(err)(encoding).getLines())
+          logCallback(errorLog)
+          System.err.println(errorLog)
         } catch {
           case t: Throwable =>
             childThreadException.set(t)


### PR DESCRIPTION
# What changes were proposed in this pull request?

in latest version, people train python mode with one python script in `PythonAlg` module. but algthrim engineer build their mode with project actually.
this patch provide a new parameter `pythonProjectPath` to fix this issue. once people set `pythonProjectPath` in their train or predict mlsql script, the mlsql system will download the python project into executor host. we can use like follow code:

```python
# get project path in your predict script
project_path = mlsql.internal_system_param['resource']['pythonProjectPath']
```
and then, you can use `project_path` in your predict function

```python
sys.path.insert(0, project_path)
```
now you got whole project in your train or predict python script.

# How was this patch tested?

None

# Spark Core Compatibility

Spark 2.2.x
Spark 2.3.x