### PR TITLE
[Enhance] Register Statement Will Explain Model

### DIFF
--- a/docs/en/mlsql-mllib-randomfores-classfication.md
+++ b/docs/en/mlsql-mllib-randomfores-classfication.md
@@ -49,11 +49,12 @@ and `fitParam.0.featuresCol`="label"
 and `fitParam.0.maxDepth`="2"
 
 -- specify group 1 parameters
-and `fitParam.0.featuresCol`="features"
-and `fitParam.0.labelCol`="label"
+and `fitParam.1.featuresCol`="features"
+and `fitParam.1.labelCol`="label"
 and `fitParam.1.maxDepth`="10"
 ;
 
+-- register RandomForest.`/tmp/model` as predict;
 ```
 
 When this script is executed, the following result will be showed in web console:

--- a/streamingpro-api/src/main/java/streaming/dsl/mmlib/SQLAlg.scala
+++ b/streamingpro-api/src/main/java/streaming/dsl/mmlib/SQLAlg.scala
@@ -18,6 +18,11 @@ trait SQLAlg extends Serializable {
     Seq.empty[(String, String)].toDF("param", "description")
   }
 
+  def explainModel(sparkSession: SparkSession, path: String, params: Map[String, String]): DataFrame = {
+    import sparkSession.implicits._
+    Seq.empty[(String, String)].toDF("key", "value")
+  }
+
   def skipPathPrefix: Boolean = false
 
   def modelType: ModelType = UndefinedType

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/RegisterAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/RegisterAdaptor.scala
@@ -1,5 +1,7 @@
 package streaming.dsl
 
+import java.util.UUID
+
 import streaming.dsl.parser.DSLSQLParser._
 import streaming.dsl.template.TemplateMerge
 
@@ -44,7 +46,10 @@ class RegisterAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslA
     if (udf != null) {
       scriptSQLExecListener.sparkSession.udf.register(functionName, udf)
     }
-    scriptSQLExecListener.setLastSelectTable(null)
+    val newdf = alg.explainModel(sparkSession, path, option)
+    val tempTable = UUID.randomUUID().toString.replace("-", "")
+    newdf.createOrReplaceTempView(tempTable)
+    scriptSQLExecListener.setLastSelectTable(tempTable)
   }
 }
 

--- a/streamingpro-mlsql/src/test/scala/streaming/test/Test.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/Test.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ArrayBuffer
   */
 object Test {
   def main(args: Array[String]): Unit = {
-//    streaming.example.OpTitanicSimple.OpTitanicSimple.main(args)
+    //    streaming.example.OpTitanicSimple.main(args)
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When you use 

```
register RandomForest.`/tmp/model` as predict;
```

The system will show you the model's information e.g. numFeatures,trees

## How was this patch tested?
None

## Spark Core Compatibility

1. Spark 2.2.x
2. Spark 2.3.x