### PR TITLE
[BIGDL support] adding BigDL LeNet demo

### DIFF
--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -2,7 +2,7 @@ name: tutorial
 channels:
   - defaults
 dependencies:
-  - python=3.6
+  - python=2.7
   - numpy=1.14.3
   - pandas=0.22.0
   - scikit-learn=0.19.1

--- a/examples/sklearn_elasticnet_wine/predict.py
+++ b/examples/sklearn_elasticnet_wine/predict.py
@@ -11,6 +11,7 @@ def predict(index, s):
     model = pickle.load(open(pickle.loads(items[1])[0] + "/model.pkl", "rb"))
     y = model.predict([feature.toArray()])
     print("------------")
+    1/0
     return [VectorUDT().serialize(Vectors.dense(y))]
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>streamingpro-opencv</module>
         <module>streamingpro-jython</module>
         <module>streamingpro-automl</module>
+        <module>streamingpro-bigdl</module>
     </modules>
 
     <properties>
@@ -56,6 +57,7 @@
         </spark.streaming.kafka.artifactId>
         <spark.sql.kafka.artifactId>spark-sql-kafka-0-10_${scala.binary.version}</spark.sql.kafka.artifactId>
         <spark.version>2.2.0</spark.version>
+        <spark.bigversion>2.2</spark.bigversion>
 
         <flink.version>1.4.2</flink.version>
         <guava.version>16.0</guava.version>
@@ -179,6 +181,7 @@
                 </spark.streaming.kafka.artifactId>
                 <spark.sql.kafka.artifactId>spark-sql-kafka-0-10_${scala.binary.version}</spark.sql.kafka.artifactId>
                 <spark.version>2.2.0</spark.version>
+                <spark.bigversion>2.2</spark.bigversion>
             </properties>
             <modules>
                 <module>streamingpro-spark-2.2.0-adaptor</module>
@@ -246,6 +249,7 @@
                 </spark.streaming.kafka.artifactId>
                 <spark.sql.kafka.artifactId>spark-sql-kafka-0-10_${scala.binary.version}</spark.sql.kafka.artifactId>
                 <spark.version>2.3.2</spark.version>
+                <spark.bigversion>2.3</spark.bigversion>
             </properties>
             <modules>
                 <module>streamingpro-spark-2.3.0-adaptor</module>

--- a/streamingpro-bigdl/pom.xml
+++ b/streamingpro-bigdl/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streamingpro</artifactId>
+        <groupId>streaming.king</groupId>
+        <version>1.1.3</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streamingpro-bigdl</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>com.intel.analytics.bigdl</groupId>
+            <artifactId>bigdl-SPARK_${spark.bigversion}</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/streamingpro-bigdl/src/main/java/streaming/dsl/mmlib/algs/BigDL.scala
+++ b/streamingpro-bigdl/src/main/java/streaming/dsl/mmlib/algs/BigDL.scala
@@ -1,0 +1,9 @@
+package streaming.dsl.mmlib.algs
+
+class BigDL {
+
+}
+
+object BigDL {
+
+}

--- a/streamingpro-commons/src/main/java/streaming/common/HDFSOperator.scala
+++ b/streamingpro-commons/src/main/java/streaming/common/HDFSOperator.scala
@@ -1,10 +1,12 @@
 package streaming.common
 
-import java.io.{BufferedReader, File, InputStreamReader}
+import java.io.{BufferedReader, ByteArrayOutputStream, File, InputStreamReader}
+import java.net.URI
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FSDataOutputStream, FileStatus, FileSystem, Path}
+import org.apache.hadoop.fs._
+import org.apache.hadoop.io.IOUtils
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
@@ -31,6 +33,20 @@ object HDFSOperator {
     }
     result.mkString("\n")
 
+  }
+
+  def readBytes(fileName: String): Array[Byte] = {
+    val fs = FileSystem.get(new Configuration())
+    val src: Path = new Path(fileName)
+    var in: FSDataInputStream = null
+    try {
+      in = fs.open(src)
+      val byteArrayOut = new ByteArrayOutputStream()
+      IOUtils.copyBytes(in, byteArrayOut, 1024, true)
+      byteArrayOut.toByteArray
+    } finally {
+      if (null != in) in.close()
+    }
   }
 
   def listModelDirectory(path: String): Seq[FileStatus] = {
@@ -100,6 +116,10 @@ object HDFSOperator {
       }
     }
 
+  }
+
+  def getFilePath(path: String) = {
+    new Path(path).toString
   }
 
   def copyToHDFS(tempLocalPath: String, path: String, cleanTarget: Boolean, cleanSource: Boolean) = {

--- a/streamingpro-mlsql/pom.xml
+++ b/streamingpro-mlsql/pom.xml
@@ -149,6 +149,17 @@
         </profile>
 
         <profile>
+            <id>bigdl</id>
+            <dependencies>
+                <dependency>
+                    <groupId>streaming.king</groupId>
+                    <artifactId>streamingpro-bigdl</artifactId>
+                    <version>${project.parent.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <id>streamingpro-spark-2.2.0-adaptor</id>
             <dependencies>
                 <dependency>
@@ -241,9 +252,9 @@
             </properties>
             <dependencies>
                 <!--<dependency>-->
-                    <!--<groupId>org.elasticsearch</groupId>-->
-                    <!--<artifactId>elasticsearch-spark-20_2.11</artifactId>-->
-                    <!--<version>5.5.2</version>-->
+                <!--<groupId>org.elasticsearch</groupId>-->
+                <!--<artifactId>elasticsearch-spark-20_2.11</artifactId>-->
+                <!--<version>5.5.2</version>-->
                 <!--</dependency>-->
                 <dependency>
                     <groupId>streaming.king</groupId>

--- a/streamingpro-mlsql/pom.xml
+++ b/streamingpro-mlsql/pom.xml
@@ -149,17 +149,6 @@
         </profile>
 
         <profile>
-            <id>bigdl</id>
-            <dependencies>
-                <dependency>
-                    <groupId>streaming.king</groupId>
-                    <artifactId>streamingpro-bigdl</artifactId>
-                    <version>${project.parent.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
             <id>streamingpro-spark-2.2.0-adaptor</id>
             <dependencies>
                 <dependency>
@@ -280,6 +269,12 @@
         <dependency>
             <groupId>streaming.king</groupId>
             <artifactId>streamingpro-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>streaming.king</groupId>
+            <artifactId>streamingpro-bigdl</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 

--- a/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -61,6 +61,13 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
       master == "local" || master.startsWith("local[")
     }
 
+    if (params.getOrDefault("streaming.bigdl.enable", "true").toString.toBoolean) {
+      conf.setIfMissing("spark.shuffle.reduceLocality.enabled", "false")
+      conf.setIfMissing("spark.shuffle.blockTransferService", "nio")
+      conf.setIfMissing("spark.scheduler.minRegisteredResourcesRatio", "1.0")
+      conf.setIfMissing("spark.speculation", "false")
+    }
+
     if (params.containsKey("streaming.ps.enable") && params.get("streaming.ps.enable").toString.toBoolean) {
       if (!isLocalMaster(conf)) {
         logger.info("register worker.sink.pservice.class with org.apache.spark.ps.cluster.PSServiceSink")
@@ -75,7 +82,6 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
       params.get("streaming.enableHiveSupport").toString.toBoolean) {
       sparkSession.enableHiveSupport()
     }
-
 
 
     val ss = if (params.containsKey("streaming.enableCarbonDataSupport") &&
@@ -120,7 +126,6 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
         psDriverBackend.start()
       }
     }
-
     ss
   }
 

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/load/batch/ModelExplain.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/load/batch/ModelExplain.scala
@@ -95,7 +95,9 @@ class ModelList(format: String, path: String, option: Map[String, String])(spark
   }
 
   override def explain: DataFrame = {
-
+    /*
+       todo: we can scan `streaming.dsl.mmlib.algs` package and get all available algs.
+     */
     val rows = sparkSession.sparkContext.parallelize(MLMapping.mapping.keys.toSeq.sorted, 1)
     sparkSession.createDataFrame(rows.filter(f => ModelSelfExplain.findAlg(f).isDefined).map { algName =>
       val sqlAlg = ModelSelfExplain.findAlg(algName).get

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLLeNet5Ext.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLLeNet5Ext.scala
@@ -2,11 +2,17 @@ package streaming.dsl.mmlib.algs
 
 import com.intel.analytics.bigdl.dlframes.{DLClassifier, DLModel}
 import com.intel.analytics.bigdl.models.lenet.LeNet5
+import com.intel.analytics.bigdl.models.utils.ModelBroadcast
 import com.intel.analytics.bigdl.nn.{ClassNLLCriterion, Module}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Engine
 import net.sf.json.JSONArray
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import streaming.dsl.mmlib.SQLAlg
+import streaming.common.HDFSOperator
+import streaming.dsl.mmlib._
 import streaming.dsl.mmlib.algs.classfication.BaseClassification
 import streaming.dsl.mmlib.algs.param.BaseParams
 import streaming.dsl.mmlib.algs.bigdl.BigDLFunctions
@@ -19,6 +25,7 @@ class SQLLeNet5Ext(override val uid: String) extends SQLAlg with MllibFunctions 
   def this() = this(BaseParams.randomUID())
 
   override def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    Engine.init
     params.get(keepVersion.name).
       map(m => set(keepVersion, m.toBoolean)).
       getOrElse($(keepVersion))
@@ -55,24 +62,67 @@ class SQLLeNet5Ext(override val uid: String) extends SQLAlg with MllibFunctions 
 
 
   override def batchPredict(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    Engine.init
     val models = load(df.sparkSession, path, params).asInstanceOf[ArrayBuffer[DLModel[Float]]]
     models.head.transform(df)
   }
 
   override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
+    Engine.init
     val (bestModelPath, baseModelPath, metaPath) = mllibModelAndMetaPath(path, params, sparkSession)
     val trainParams = sparkSession.read.parquet(metaPath + "/0").collect().head.getAs[Map[String, String]]("trainParams")
 
     val featureSize = JSONArray.fromObject(trainParams("featureSize")).map(f => f.asInstanceOf[Int]).toArray
 
-    val model = Module.loadModule[Float](bestModelPath(0))
+    val model = Module.loadModule[Float](HDFSOperator.getFilePath(bestModelPath(0)))
     val dlModel = new DLModel[Float](model, featureSize)
     ArrayBuffer(dlModel)
   }
 
   override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {
-    null
+    val dlmodel = _model.asInstanceOf[ArrayBuffer[DLModel[Float]]].head
+    val featureSize = dlmodel.featureSize
+    val modelBroadCast = ModelBroadcast[Float]().broadcast(sparkSession.sparkContext, dlmodel.model.evaluate())
+
+
+    val f = (vec: Vector) => {
+
+      val localModel = modelBroadCast.value()
+      val featureTensor = Tensor(vec.toArray.map(f => f.toFloat), featureSize)
+      val output = localModel.forward(featureTensor)
+      val res = output.toTensor[Float].clone().storage().array().map(f => f.toDouble)
+      Vectors.dense(res)
+    }
+
+    UserDefinedFunction(f, VectorType, Some(Seq(VectorType)))
   }
+
+  override def modelType: ModelType = AlgType
+
+  override def doc: Doc = super.doc
+
+  override def codeExample: Code = Code(SQLCode,
+    """
+      |set json = '''{}''';
+      |load jsonStr.`json` as emptyData;
+      |
+      |run emptyData as MnistLoaderExt.`` where
+      |mnistDir="/Users/allwefantasy/Downloads/mnist"
+      |as data;
+      |
+      |train data as LeNet5Ext.`/tmp/lenet` where
+      |fitParam.0.featureSize="[28,28]"
+      |and fitParam.0.classNum=10;
+      |
+      |predict data as LeNet5Ext.`/tmp/lenet`;
+      |
+      |register LeNet5Ext.`/tmp/lenet` as mnistPredict;
+      |
+      |select
+      |vec_argmax(mnistPredict(vec_dense(features))) as predict_label,
+      |label from data
+      |as output;
+    """.stripMargin)
 }
 
 case class BigDLDefaultConfig(batchSize: Int = 128, maxEpoch: Int = 1)

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLLeNet5Ext.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLLeNet5Ext.scala
@@ -1,0 +1,78 @@
+package streaming.dsl.mmlib.algs
+
+import com.intel.analytics.bigdl.dlframes.{DLClassifier, DLModel}
+import com.intel.analytics.bigdl.models.lenet.LeNet5
+import com.intel.analytics.bigdl.nn.{ClassNLLCriterion, Module}
+import net.sf.json.JSONArray
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import streaming.dsl.mmlib.SQLAlg
+import streaming.dsl.mmlib.algs.classfication.BaseClassification
+import streaming.dsl.mmlib.algs.param.BaseParams
+import streaming.dsl.mmlib.algs.bigdl.BigDLFunctions
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+class SQLLeNet5Ext(override val uid: String) extends SQLAlg with MllibFunctions with BigDLFunctions with BaseClassification {
+
+  def this() = this(BaseParams.randomUID())
+
+  override def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    params.get(keepVersion.name).
+      map(m => set(keepVersion, m.toBoolean)).
+      getOrElse($(keepVersion))
+
+    val eTable = params.get(evaluateTable.name)
+
+    SQLPythonFunc.incrementVersion(path, $(keepVersion))
+    val spark = df.sparkSession
+
+
+    bigDLClassifyTrain[Float](df, path, params, (newFitParam) => {
+      val model = LeNet5(classNum = newFitParam("classNum").toInt)
+      val criterion = ClassNLLCriterion[Float]()
+      val alg = new DLClassifier[Float](model, criterion,
+        JSONArray.fromObject(newFitParam("featureSize")).map(f => f.asInstanceOf[Int]).toArray)
+      alg
+    }, (_model, newFitParam) => {
+      eTable match {
+        case Some(etable) =>
+          val model = _model
+          val evaluateTableDF = spark.table(etable)
+          val predictions = model.transform(evaluateTableDF)
+          multiclassClassificationEvaluate(predictions, (evaluator) => {
+            evaluator.setLabelCol(newFitParam.getOrElse("labelCol", "label"))
+            evaluator.setPredictionCol("prediction")
+          })
+
+        case None => List()
+      }
+    })
+
+    formatOutput(getModelMetaData(spark, path))
+  }
+
+
+  override def batchPredict(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    val models = load(df.sparkSession, path, params).asInstanceOf[ArrayBuffer[DLModel[Float]]]
+    models.head.transform(df)
+  }
+
+  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
+    val (bestModelPath, baseModelPath, metaPath) = mllibModelAndMetaPath(path, params, sparkSession)
+    val trainParams = sparkSession.read.parquet(metaPath + "/0").collect().head.getAs[Map[String, String]]("trainParams")
+
+    val featureSize = JSONArray.fromObject(trainParams("featureSize")).map(f => f.asInstanceOf[Int]).toArray
+
+    val model = Module.loadModule[Float](bestModelPath(0))
+    val dlModel = new DLModel[Float](model, featureSize)
+    ArrayBuffer(dlModel)
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {
+    null
+  }
+}
+
+case class BigDLDefaultConfig(batchSize: Int = 128, maxEpoch: Int = 1)

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLMnistLoaderExt.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLMnistLoaderExt.scala
@@ -1,0 +1,107 @@
+package streaming.dsl.mmlib.algs
+
+import java.nio.ByteBuffer
+
+import com.intel.analytics.bigdl.dataset.{ByteRecord, DataSet, DistributedDataSet, MiniBatch}
+import com.intel.analytics.bigdl.dataset.image.{BytesToGreyImg, GreyImgNormalizer, GreyImgToBatch}
+import com.intel.analytics.bigdl.models.lenet.Utils.{trainMean, trainStd}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Engine
+import org.apache.spark.ml.param.{BooleanParam, Param}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import streaming.common.HDFSOperator
+import streaming.dsl.mmlib.{AlgType, ModelType, ProcessType, SQLAlg}
+import streaming.dsl.mmlib.algs.param.BaseParams
+import streaming.session.MLSQLException
+
+class SQLMnistLoaderExt(override val uid: String) extends SQLAlg with BaseParams {
+
+  def this() = this(BaseParams.randomUID())
+
+  def load(featureFile: String, labelFile: String) = {
+
+    val featureBuffer = ByteBuffer.wrap(HDFSOperator.readBytes(featureFile))
+    val labelBuffer = ByteBuffer.wrap(HDFSOperator.readBytes(labelFile))
+
+    val labelMagicNumber = labelBuffer.getInt()
+    require(labelMagicNumber == 2049)
+    val featureMagicNumber = featureBuffer.getInt()
+    require(featureMagicNumber == 2051)
+    val labelCount = labelBuffer.getInt()
+    val featureCount = featureBuffer.getInt()
+    require(labelCount == featureCount)
+    val rowNum = featureBuffer.getInt()
+    val colNum = featureBuffer.getInt()
+
+    val result = new Array[ByteRecord](featureCount)
+    var i = 0
+    while (i < featureCount) {
+      val img = new Array[Byte]((rowNum * colNum))
+      var y = 0
+      while (y < rowNum) {
+        var x = 0
+        while (x < colNum) {
+          img(x + y * colNum) = featureBuffer.get()
+          x += 1
+        }
+        y += 1
+      }
+      result(i) = ByteRecord(img, labelBuffer.get().toFloat + 1.0f)
+      i += 1
+    }
+
+    result
+  }
+
+  override def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    Engine.init
+    params.get(mnistDir.name).
+      map(m => set(mnistDir, m)).getOrElse {
+      throw new MLSQLException(s"mnistDir is required. ${mnistDir.doc}")
+    }
+
+    params.get(dataType.name).
+      map(m => set(dataType, m)).
+      getOrElse("")
+
+    val trainData = $(mnistDir) + "/train-images.idx3-ubyte"
+    val trainLabel = $(mnistDir) + "/train-labels.idx1-ubyte"
+    val validationData = $(mnistDir) + "/t10k-images.idx3-ubyte"
+    val validationLabel = $(mnistDir) + "/t10k-labels.idx1-ubyte"
+
+    val data = if ($(dataType) == "train") trainData else validationData
+    val validate = if ($(dataType) == "train") trainLabel else validationLabel
+
+    val trainSet = DataSet.array(load(data, validate), df.sparkSession.sparkContext) ->
+      BytesToGreyImg(28, 28) -> GreyImgNormalizer(trainMean, trainStd) -> GreyImgToBatch(1)
+
+    val trainingRDD: RDD[Data[Float]] = trainSet.
+      asInstanceOf[DistributedDataSet[MiniBatch[Float]]].data(false).map(batch => {
+      val feature = batch.getInput().asInstanceOf[Tensor[Float]]
+      val label = batch.getTarget().asInstanceOf[Tensor[Float]]
+      Data[Float](feature.storage().array(), label.storage().array())
+    })
+    val trainingDF = df.sparkSession.createDataFrame(trainingRDD).toDF("features", "label")
+    trainingDF
+  }
+
+  override def batchPredict(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    train(df, path, params)
+  }
+
+  override def modelType: ModelType = ProcessType
+
+  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
+    throw new MLSQLException(s"register statement is not support by ${getClass.getName}")
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = ???
+
+  final val mnistDir: Param[String] = new Param[String](this, "mnistDir", "mnistDir directory which contains 4 ubyte files")
+  final val dataType: Param[String] = new Param[String](this, "dataType", "load train|validate data")
+  set(dataType, "train")
+}
+
+private case class Data[T](featureData: Array[T], labelData: Array[T])

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/bigdl/BigDLFunctions.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/bigdl/BigDLFunctions.scala
@@ -1,0 +1,84 @@
+package streaming.dsl.mmlib.algs.bigdl
+
+import com.intel.analytics.bigdl.dlframes.{DLClassifier, DLModel}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.apache.spark.sql.types._
+import streaming.common.ScalaMethodMacros._
+import streaming.dsl.mmlib.algs._
+import streaming.log.{Logging, WowLog}
+
+
+trait BigDLFunctions extends Functions with Logging with WowLog with Serializable {
+  def bigDLClassifyTrain[T](df: DataFrame, path: String, params: Map[String, String],
+                            modelType: (Map[String, String]) => DLClassifier[T],
+                            evaluate: (DLModel[T], Map[String, String]) => List[MetricValue]
+                           ) = {
+
+    val keepVersion = params.getOrElse("keepVersion", "true").toBoolean
+
+    val mf = (trainData: DataFrame, fitParam: Map[String, String], modelIndex: Int) => {
+      require(fitParam.contains("classNum"), "classNum is required")
+      require(fitParam.contains("featureSize"), "featureSize is required")
+
+      val newFitParam = Map(
+        str[BigDLDefaultConfig](_.batchSize) -> BigDLDefaultConfig().batchSize.toString,
+        str[BigDLDefaultConfig](_.maxEpoch) -> BigDLDefaultConfig().maxEpoch.toString
+      ) ++ fitParam
+
+      val alg = modelType(newFitParam)
+      configureModel(alg, newFitParam)
+
+      logInfo(format(s"[training] [alg=${alg.getClass.getName}] [keepVersion=${keepVersion}]"))
+
+      var status = "success"
+      val modelTrainStartTime = System.currentTimeMillis()
+      val modelPath = SQLPythonFunc.getAlgModelPath(path, keepVersion) + "/" + modelIndex
+      var scores: List[MetricValue] = List()
+      try {
+        val newmodel = alg.fit(trainData)
+        newmodel.model.saveModule(modelPath)
+        scores = evaluate(newmodel, newFitParam)
+        logInfo(format(s"[trained] [alg=${alg.getClass.getName}] [metrics=${scores}] [model hyperparameters=${
+          newmodel.explainParams().replaceAll("\n", "\t")
+        }]"))
+      } catch {
+        case e: Exception =>
+          logInfo(format_exception(e))
+          status = "fail"
+      }
+      val modelTrainEndTime = System.currentTimeMillis()
+      val metrics = scores.map(score => Row.fromSeq(Seq(score.name, score.value))).toArray
+      Row.fromSeq(Seq(modelPath, modelIndex, alg.getClass.getName, metrics, status, modelTrainStartTime, modelTrainEndTime, fitParam))
+    }
+    var fitParam = arrayParamsWithIndex("fitParam", params)
+    if (fitParam.size == 0) {
+      fitParam = Array((0, Map[String, String]()))
+    }
+
+    val wowRes = fitParam.map { fp =>
+      mf(df, fp._2, fp._1)
+    }
+
+    val wowRDD = df.sparkSession.sparkContext.parallelize(wowRes, 1)
+
+    df.sparkSession.createDataFrame(wowRDD, StructType(Seq(
+      StructField("modelPath", StringType),
+      StructField("algIndex", IntegerType),
+      StructField("alg", StringType),
+      StructField("metrics", ArrayType(StructType(Seq(
+        StructField(name = "name", dataType = StringType),
+        StructField(name = "value", dataType = DoubleType)
+      )))),
+
+      StructField("status", StringType),
+      StructField("startTime", LongType),
+      StructField("endTime", LongType),
+      StructField("trainParams", MapType(StringType, StringType))
+    ))).
+      write.
+      mode(SaveMode.Overwrite).
+      parquet(SQLPythonFunc.getAlgMetalPath(path, keepVersion) + "/0")
+  }
+
+
+}

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/bigdl/BigDLFunctions.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/bigdl/BigDLFunctions.scala
@@ -3,6 +3,7 @@ package streaming.dsl.mmlib.algs.bigdl
 import com.intel.analytics.bigdl.dlframes.{DLClassifier, DLModel}
 import org.apache.spark.sql.{DataFrame, Row, SaveMode}
 import org.apache.spark.sql.types._
+import streaming.common.HDFSOperator
 import streaming.common.ScalaMethodMacros._
 import streaming.dsl.mmlib.algs._
 import streaming.log.{Logging, WowLog}
@@ -36,7 +37,7 @@ trait BigDLFunctions extends Functions with Logging with WowLog with Serializabl
       var scores: List[MetricValue] = List()
       try {
         val newmodel = alg.fit(trainData)
-        newmodel.model.saveModule(modelPath)
+        newmodel.model.saveModule(HDFSOperator.getFilePath(modelPath))
         scores = evaluate(newmodel, newFitParam)
         logInfo(format(s"[trained] [alg=${alg.getClass.getName}] [metrics=${scores}] [model hyperparameters=${
           newmodel.explainParams().replaceAll("\n", "\t")

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/param/BaseParams.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/param/BaseParams.scala
@@ -16,6 +16,7 @@ trait BaseParams extends WowParams {
     "The table name of test dataset when tranning",
     (value: String) => true)
 
+
   final def getEvaluateTable: String = $(evaluateTable)
 
   def setEvaluateTable(value: String): this.type = set(evaluateTable, value)

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/python/PythonTrain.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/python/PythonTrain.scala
@@ -158,6 +158,7 @@ class PythonTrain extends Functions with Serializable {
            |train data as PythonAlg.`/tmp/abc` where keepLocalDirectory="true";
            |----------------------------------------------------------------
          """.stripMargin
+      logInfo(format(execDesc))
 
       val modelTrainStartTime = System.currentTimeMillis()
 

--- a/streamingpro-mlsql/src/test/scala/streaming/test/Test.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/Test.scala
@@ -1,7 +1,29 @@
 package streaming.test
 
+import java.nio.ByteBuffer
+import java.nio.file.{Files, Paths}
+
 import org.apache.http.client.fluent.{Form, Request}
+import org.apache.spark.SparkContext
 import org.apache.spark.graphx.VertexId
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SQLContext
+import com.intel.analytics.bigdl._
+import com.intel.analytics.bigdl.dataset.image.{BytesToGreyImg, GreyImgNormalizer, GreyImgToBatch}
+import com.intel.analytics.bigdl.dataset.{DataSet, DistributedDataSet, MiniBatch, _}
+import com.intel.analytics.bigdl.dlframes.DLClassifier
+import com.intel.analytics.bigdl.models.lenet.LeNet5
+import com.intel.analytics.bigdl.models.lenet.Utils._
+import com.intel.analytics.bigdl.nn.ClassNLLCriterion
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+import com.intel.analytics.bigdl.utils.{Engine, File, LoggerFilter}
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SQLContext
+import streaming.dsl.ScriptSQLExec
+import streaming.dsl.mmlib.algs.SQLLeNet5Ext
 
 
 /**
@@ -9,16 +31,108 @@ import org.apache.spark.graphx.VertexId
   */
 object Test {
   def main(args: Array[String]): Unit = {
-    val sql = "select pj(vec_dense(features)) as p1 "
 
-    val res = Request.Post("http://127.0.0.1:9003/model/predict").bodyForm(Form.form().
-      add("sql", sql).
-      add("data", s"""[{"features":[ 0.045, 8.8, 1.001, 45.0, 7.0, 170.0, 0.27, 0.45, 0.36, 3.0, 20.7 ]}]""").
-      add("dataType", "row")
-      .build()).execute().returnContent().asString()
-    println(res)
   }
 }
+
+
+object DLClassifierLeNet {
+  def load(featureFile: String, labelFile: String): Array[ByteRecord] = {
+
+    val featureBuffer = if (featureFile.startsWith("hdfs:")) {
+      ByteBuffer.wrap(File.readHdfsByte(featureFile))
+    } else {
+      ByteBuffer.wrap(Files.readAllBytes(Paths.get(featureFile)))
+    }
+    val labelBuffer = if (featureFile.startsWith("hdfs:")) {
+      ByteBuffer.wrap(File.readHdfsByte(labelFile))
+    } else {
+      ByteBuffer.wrap(Files.readAllBytes(Paths.get(labelFile)))
+    }
+    val labelMagicNumber = labelBuffer.getInt()
+
+    require(labelMagicNumber == 2049)
+    val featureMagicNumber = featureBuffer.getInt()
+    require(featureMagicNumber == 2051)
+
+    val labelCount = labelBuffer.getInt()
+    val featureCount = featureBuffer.getInt()
+    require(labelCount == featureCount)
+
+    val rowNum = featureBuffer.getInt()
+    val colNum = featureBuffer.getInt()
+
+    val result = new Array[ByteRecord](featureCount)
+    var i = 0
+    while (i < featureCount) {
+      val img = new Array[Byte]((rowNum * colNum))
+      var y = 0
+      while (y < rowNum) {
+        var x = 0
+        while (x < colNum) {
+          img(x + y * colNum) = featureBuffer.get()
+          x += 1
+        }
+        y += 1
+      }
+      result(i) = ByteRecord(img, labelBuffer.get().toFloat + 1.0f)
+      i += 1
+    }
+
+    result
+  }
+
+  LoggerFilter.redirectSparkInfoLogs()
+
+  def main(args: Array[String]): Unit = {
+    val mlsqlContext = ScriptSQLExec.contextGetOrForTest()
+    val conf = Engine.createSparkConf()
+      .setAppName("MLPipeline Example")
+      .set("spark.task.maxFailures", "1")
+      .setMaster("local[*]")
+    val sc = new SparkContext(conf)
+    val sqLContext = SQLContext.getOrCreate(sc)
+    Engine.init
+
+    val folder = "/Users/allwefantasy/Downloads/mnist"
+    val trainData = folder + "/train-images.idx3-ubyte"
+    val trainLabel = folder + "/train-labels.idx1-ubyte"
+    val validationData = folder + "/t10k-images.idx3-ubyte"
+    val validationLabel = folder + "/t10k-labels.idx1-ubyte"
+
+    val trainSet = DataSet.array(load(trainData, trainLabel), sc) ->
+      BytesToGreyImg(28, 28) -> GreyImgNormalizer(trainMean, trainStd) -> GreyImgToBatch(1)
+
+    val trainingRDD: RDD[Data[Float]] = trainSet.
+      asInstanceOf[DistributedDataSet[MiniBatch[Float]]].data(false).map(batch => {
+      val feature = batch.getInput().asInstanceOf[Tensor[Float]]
+      val label = batch.getTarget().asInstanceOf[Tensor[Float]]
+      Data[Float](feature.storage().array(), label.storage().array())
+    })
+    val trainingDF = sqLContext.createDataFrame(trainingRDD).toDF("features", "label")
+
+    val bigdl = new SQLLeNet5Ext()
+    bigdl.train(trainingDF, "/tmp/jack", Map("fitParam.0.featureSize" -> "[28,28]", "fitParam.0.classNum" -> "10"))
+
+
+    val validationSet = DataSet.array(load(validationData, validationLabel), sc) ->
+      BytesToGreyImg(28, 28) -> GreyImgNormalizer(testMean, testStd) -> GreyImgToBatch(1)
+
+    val validationRDD: RDD[Data[Float]] = validationSet.
+      asInstanceOf[DistributedDataSet[MiniBatch[Float]]].data(false).map { batch =>
+      val feature = batch.getInput().asInstanceOf[Tensor[Float]]
+      val label = batch.getTarget().asInstanceOf[Tensor[Float]]
+      Data[Float](feature.storage().array(), label.storage().array())
+    }
+    val validationDF = sqLContext.createDataFrame(validationRDD).toDF("features", "label")
+    val transformed = bigdl.batchPredict(validationDF, "/tmp/jack", Map())
+    transformed.show()
+    sc.stop()
+
+  }
+}
+
+private case class Data[T](featureData: Array[T], labelData: Array[T])
 
 object UdfUtils {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Example:

```sql
set json = '''{}''';
load jsonStr.`json` as emptyData;

run emptyData as MnistLoaderExt.`` where
mnistDir="/Users/allwefantasy/Downloads/mnist"
as data;

train data as LeNet5Ext.`/tmp/lenet` where
fitParam.0.featureSize="[28,28]"
and fitParam.0.classNum="10";

predict data as LeNet5Ext.`/tmp/lenet`;

register LeNet5Ext.`/tmp/lenet` as mnistPredict;

select
vec_argmax(mnistPredict(vec_dense(features))) as predict_label,
label from data
as output;
```

## How was this patch tested?
Manually test.

## Spark Core Compatibility

1. Spark 2.2.x
2. Spark 2.3.x

## Problems

None