### PR TITLE
简化udf函数使用

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/ScriptUDF.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/ScriptUDF.scala
@@ -23,7 +23,7 @@ class ScriptUDF extends SQLAlg with MllibFunctions with Functions {
       register ScalaScriptUDF.`scriptText` as udf1;
    */
   override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
-    val res = sparkSession.table(path).head().getString(0)
+    val res = params.get("code").getOrElse(sparkSession.table(path).head().getString(0))
 
     val lang = params.getOrElse("lang", "scala")
     val udfType = params.getOrElse("udfType", "udf")

--- a/streamingpro-mlsql/src/test/scala/streaming/test/Test.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/Test.scala
@@ -33,9 +33,7 @@ import streaming.dsl.mmlib.algs.SQLBigDLClassifyExt
   */
 object Test {
   def main(args: Array[String]): Unit = {
-    val (a,b) = "fitParam.[group].a.b".split("\\.").splitAt(2)
-    println(a.mkString(","))
-    println(b.mkString(","))
+   println(new SQLBigDLClassifyExt().doc.doc)
   }
 }
 


### PR DESCRIPTION

```sql
register ScriptUDF.`` as count_board options lang="python"
    and methodName="apply"
    and dataType="map(string,integer)"
    and code='''
def apply(self, s):
    from collections import Counter
    return dict(Counter(s))
    '''
;
```

可以直接在register里定义函数。