### PR TITLE
[CORE][fix] new session will inherit Root SparkSession in sessionPerUser mode

### DIFF
--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLException.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLException.scala
@@ -1,4 +1,4 @@
-package streaming.session
+package org.apache.spark.sql.mlsql.session
 
 import java.sql.SQLException
 

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLOperation.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLOperation.scala
@@ -1,5 +1,4 @@
-package streaming.session
-
+package org.apache.spark.sql.mlsql.session
 
 import streaming.log.Logging
 

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLOperationManager.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLOperationManager.scala
@@ -1,4 +1,4 @@
-package streaming.session
+package org.apache.spark.sql.mlsql.session
 
 import streaming.log.Logging
 

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLSession.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLSession.scala
@@ -1,4 +1,4 @@
-package streaming.session
+package org.apache.spark.sql.mlsql.session
 
 import java.io.IOException
 

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLSparkSession.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/MLSQLSparkSession.scala
@@ -1,19 +1,18 @@
-package streaming.session
+package org.apache.spark.sql.mlsql.session
 
-import java.lang.reflect.{UndeclaredThrowableException}
+import java.lang.reflect.UndeclaredThrowableException
 import java.security.PrivilegedExceptionAction
 import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.{TimeoutException}
+import java.util.concurrent.TimeoutException
 
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SparkSession
 import streaming.log.Logging
-
 import scala.collection.mutable.{HashSet => MHSet}
 
-
 import org.apache.spark.MLSQLConf._
+import org.apache.spark.sql.mlsql.session.MLSQLException
 import streaming.core.strategy.platform.{PlatformManager, SparkRuntime}
 
 
@@ -42,7 +41,7 @@ class MLSQLSparkSession(userName: String, conf: Map[String, String]) extends Log
 
     SparkSessionCacheManager.get.getAndIncrease(userName) match {
       case Some(ss) =>
-        _sparkSession = ss.newSession()
+        _sparkSession = ss.cloneSession()
       case _ =>
         MLSQLSparkSession.setPartiallyConstructed(userName)
         notifyAll()
@@ -54,7 +53,7 @@ class MLSQLSparkSession(userName: String, conf: Map[String, String]) extends Log
   private[this] def create(sessionConf: Map[String, String]): Unit = {
     log.info(s"--------- Create new SparkSession for $userName ----------")
     try {
-      _sparkSession = PlatformManager.getRuntime.asInstanceOf[SparkRuntime].sparkSession.newSession()
+      _sparkSession = PlatformManager.getRuntime.asInstanceOf[SparkRuntime].sparkSession.cloneSession()
       SparkSessionCacheManager.get.set(userName, _sparkSession)
     } catch {
       case e: Exception =>

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/OpIdentifier.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/OpIdentifier.scala
@@ -1,4 +1,4 @@
-package streaming.session
+package org.apache.spark.sql.mlsql.session
 
 /**
   * Created by allwefantasy on 4/6/2018.

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/ReflectUtils.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/ReflectUtils.scala
@@ -1,4 +1,4 @@
-package streaming.session
+package org.apache.spark.sql.mlsql.session
 
 import streaming.log.Logging
 import scala.util.{Failure, Success, Try}

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/SessionIdentifier.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/SessionIdentifier.scala
@@ -1,0 +1,7 @@
+package org.apache.spark.sql.mlsql.session
+
+/**
+  * Created by allwefantasy on 4/6/2018.
+  */
+
+case class SessionIdentifier(owner: String)

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/SessionIdentifier.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/SessionIdentifier.scala
@@ -1,7 +1,3 @@
 package org.apache.spark.sql.mlsql.session
 
-/**
-  * Created by allwefantasy on 4/6/2018.
-  */
-
 case class SessionIdentifier(owner: String)

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/SessionManager.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/SessionManager.scala
@@ -1,4 +1,4 @@
-package streaming.session
+package org.apache.spark.sql.mlsql.session
 
 import java.util.concurrent.ConcurrentHashMap
 

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/SparkSessionCacheManager.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/SparkSessionCacheManager.scala
@@ -1,4 +1,4 @@
-package streaming.session
+package org.apache.spark.sql.mlsql.session
 
 /**
   * Created by allwefantasy on 3/6/2018.

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/operation/OperationState.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/sql/mlsql/session/operation/OperationState.scala
@@ -1,6 +1,7 @@
-package streaming.session.operation
+package org.apache.spark.sql.mlsql.session.operation
 
-import streaming.session.MLSQLException
+import org.apache.spark.sql.mlsql.session.MLSQLException
+
 
 /**
   * Created by allwefantasy on 4/6/2018.

--- a/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -1,24 +1,20 @@
 package streaming.core.strategy.platform
 
 import java.lang.reflect.Modifier
-import java.util.{Map => JMap}
 import java.util.concurrent.atomic.AtomicReference
-import java.util.logging.{Level, Logger}
+import java.util.logging.Logger
+import java.util.{Map => JMap}
+
+import scala.collection.JavaConversions._
 
 import net.csdn.common.reflect.ReflectHelper
+import org.apache.spark.{CarbonCoreVersion, SparkConf, SparkCoreVersion, SparkRuntimeOperator, WowFastSparkContext}
 import org.apache.spark.ps.cluster.PSDriverBackend
 import org.apache.spark.ps.local.LocalPSSchedulerBackend
+import org.apache.spark.sql.mlsql.session.{SessionIdentifier, SessionManager}
 import org.apache.spark.sql.{SQLContext, SparkSession}
 import streaming.common.ScalaObjectReflect
 import streaming.core.StreamingproJobManager
-import streaming.session.{SessionIdentifier, SessionManager}
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkRuntimeOperator
-import org.apache.spark.CarbonCoreVersion
-import org.apache.spark.WowFastSparkContext
-import org.apache.spark.SparkCoreVersion
-
-import scala.collection.JavaConversions._
 
 /**
   * Created by allwefantasy on 30/3/2017.

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLCacheExt.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLCacheExt.scala
@@ -1,11 +1,11 @@
 package streaming.dsl.mmlib.algs
 
 import org.apache.spark.ml.param.{BooleanParam, Param}
-import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.mlsql.session.MLSQLException
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import streaming.dsl.mmlib._
 import streaming.dsl.mmlib.algs.param.{BaseParams, WowParams}
-import streaming.session.MLSQLException
 
 
 class SQLCacheExt(override val uid: String) extends SQLAlg with WowParams {

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLImageLoaderExt.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLImageLoaderExt.scala
@@ -8,12 +8,12 @@ import com.intel.analytics.bigdl.utils.Engine
 import org.apache.spark.ml.param.{IntParam, Param}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.mlsql.session.MLSQLException
 import streaming.common.{ScriptCacheKey, SourceCodeCompiler}
 import streaming.dsl.ScriptSQLExec
 import streaming.dsl.mmlib._
 import streaming.dsl.mmlib.algs.param.BaseParams
 import streaming.log.{Logging, WowLog}
-import streaming.session.MLSQLException
 
 
 class SQLImageLoaderExt(override val uid: String) extends SQLAlg with BaseParams with Logging with WowLog {

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLMnistLoaderExt.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLMnistLoaderExt.scala
@@ -11,10 +11,10 @@ import org.apache.spark.ml.param.{BooleanParam, Param}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.mlsql.session.MLSQLException
 import streaming.common.HDFSOperator
 import streaming.dsl.mmlib.{AlgType, ModelType, ProcessType, SQLAlg}
 import streaming.dsl.mmlib.algs.param.BaseParams
-import streaming.session.MLSQLException
 
 class SQLMnistLoaderExt(override val uid: String) extends SQLAlg with BaseParams {
 

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/bigdl/BigDLClassifyExtParamsExtractor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/bigdl/BigDLClassifyExtParamsExtractor.scala
@@ -1,9 +1,9 @@
 package streaming.dsl.mmlib.algs.bigdl
 
 import com.intel.analytics.bigdl.optim.{Loss, _}
+import org.apache.spark.sql.mlsql.session.MLSQLException
 import streaming.common.ScalaObjectReflect
 import streaming.dsl.mmlib.algs.SQLBigDLClassifyExt
-import streaming.session.MLSQLException
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/python/Project.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/python/Project.scala
@@ -6,12 +6,12 @@ import java.util.UUID
 
 import net.csdn.common.settings.{ImmutableSettings, Settings}
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.mlsql.session.MLSQLException
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods.parse
 import streaming.common.HDFSOperator
 import streaming.common.shell.ShellCommand
 import streaming.log.{Logging, WowLog}
-import streaming.session.MLSQLException
 
 object PythonAlgProject extends Logging with WowLog {
 

--- a/streamingpro-mlsql/src/main/java/streaming/session/SessionIdentifier.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/session/SessionIdentifier.scala
@@ -1,7 +1,0 @@
-package streaming.session
-
-/**
-  * Created by allwefantasy on 4/6/2018.
-  */
-
-case class SessionIdentifier(owner: String)

--- a/streamingpro-mlsql/src/test/scala/org/apache/spark/streaming/BasicSparkOperation.scala
+++ b/streamingpro-mlsql/src/test/scala/org/apache/spark/streaming/BasicSparkOperation.scala
@@ -35,9 +35,14 @@ class BasicSparkOperation extends FlatSpec with Matchers {
       asInstanceOf[java.util.List[java.util.Map[Any, Any]]]
   }
 
-  def setupBatchContext(batchParams: Array[String], configFilePath: String) = {
-    val extraParam = Array("-streaming.job.file.path", configFilePath)
-    val params = new ParamsUtil(batchParams ++ extraParam)
+  def setupBatchContext(batchParams: Array[String], configFilePath: String = null) = {
+    var params: ParamsUtil = null
+    if (configFilePath != null) {
+      val extraParam = Array("-streaming.job.file.path", configFilePath)
+      params = new ParamsUtil(batchParams ++ extraParam)
+    } else {
+      params = new ParamsUtil(batchParams)
+    }
     PlatformManager.getOrCreate.run(params, false)
     val runtime = PlatformManager.getRuntime.asInstanceOf[SparkRuntime]
     runtime


### PR DESCRIPTION

# What changes were proposed in this pull request?
- [x] fix #671. new session will inherit Root SparkSession in sessionPerUser mode
# How was this patch tested?
```
mvn -Pcrawler -Phive-thrift-server -Pdsl -Pstreamingpro-spark-2.3.0-adaptor -Pspark-2.3.0 -am -pl streamingpro-mlsql clean test -Dsuites="*SessionSpec"
```
# Spark Core Compatibility
- [x] All