### PR TITLE
Fix carbonata support

### DIFF
--- a/streamingpro-api/src/main/java/streaming/dsl/mmlib/SQLAlg.scala
+++ b/streamingpro-api/src/main/java/streaming/dsl/mmlib/SQLAlg.scala
@@ -38,7 +38,7 @@ trait SQLAlg extends Serializable {
   def codeExample: Code = Code(SQLCode, "")
 
   def coreCompatibility: Seq[CoreVersion] = {
-    Seq(Core_2_2_x, Core_2_3_x, Core_2_4_x)
+    Seq(Core_2_2_x, Core_2_3_1, Core_2_3_2, Core_2_3_x, Core_2_4_x)
   }
 
 }
@@ -90,6 +90,10 @@ sealed abstract class CoreVersion
 )
 
 case object Core_2_2_x extends CoreVersion("2.2.x")
+
+case object Core_2_3_1 extends CoreVersion("2.3.1")
+
+case object Core_2_3_2 extends CoreVersion("2.3.2")
 
 case object Core_2_3_x extends CoreVersion("2.3.x")
 

--- a/streamingpro-mlsql/pom.xml
+++ b/streamingpro-mlsql/pom.xml
@@ -77,16 +77,74 @@
                 <dependency>
                     <groupId>org.apache.carbondata</groupId>
                     <artifactId>carbondata-spark2</artifactId>
-                    <version>1.3.1</version>
+                    <version>1.5.0</version>
                     <exclusions>
                         <exclusion>
                             <groupId>org.apache.spark</groupId>
-                            <artifactId>spark-repl_2.11</artifactId>
+                            <artifactId>spark-repl_${scala.binary.version}</artifactId>
                         </exclusion>
                         <exclusion>
                             <groupId>org.apache.spark</groupId>
-                            <artifactId>spark-repl_2.11</artifactId>
+                            <artifactId>spark-repl_${scala.binary.version}</artifactId>
                         </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-core_${scala.binary.version}</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-sql-kafka-0-10_${scala.binary.version}</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.spark</groupId>
+                            <artifactId>spark-core_${scala.binary.version}</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>net.java.dev.jets3t</groupId>
+                            <artifactId>jets3t</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>net.java.dev.jets3t</groupId>
+                            <artifactId>jets3t</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.avro</groupId>
+                            <artifactId>avro</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.httpcomponents</groupId>
+                            <artifactId>httpclient</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.hadoop</groupId>
+                            <artifactId>hadoop-client</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.hadoop</groupId>
+                            <artifactId>hadoop-common</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.hadoop</groupId>
+                            <artifactId>hadoop-hdfs</artifactId>
+                        </exclusion>
+
+
                     </exclusions>
                 </dependency>
             </dependencies>

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/SparkCoreVersion.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/SparkCoreVersion.scala
@@ -1,5 +1,7 @@
 package org.apache.spark
 
+import _root_.streaming.dsl.mmlib._
+
 /**
   * Created by allwefantasy on 20/9/2018.
   */
@@ -15,18 +17,27 @@ object SparkCoreVersion {
   }
 
   def is_2_2_X() = {
-    version == VERSION_2_2_X
+    version == Core_2_2_x.coreVersion
   }
 
-  def is_2_3_X() = {
-    version == VERSION_2_3_X
+  def is_2_3_1() = {
+    exactVersion == Core_2_3_1.coreVersion
+  }
+
+  def is_2_3_2() = {
+    exactVersion == Core_2_3_2.coreVersion
   }
 
   def is_2_4_X() = {
-    version == VERSION_2_4_X
+    version == Core_2_4_x.coreVersion
   }
 
-  val VERSION_2_2_X = "2.2.x"
-  val VERSION_2_3_X = "2.3.x"
-  val VERSION_2_4_X = "2.4.x"
+
+}
+
+object CarbonCoreVersion {
+  def coreCompatibility(version: String, exactVersion: String) = {
+    val vs = Seq(Core_2_2_x, Core_2_3_1).map(f => f.coreVersion).toSet
+    vs.contains(version) || vs.contains(exactVersion)
+  }
 }

--- a/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -3,16 +3,20 @@ package streaming.core.strategy.platform
 import java.lang.reflect.Modifier
 import java.util.{Map => JMap}
 import java.util.concurrent.atomic.AtomicReference
-import java.util.logging.Logger
+import java.util.logging.{Level, Logger}
 
 import net.csdn.common.reflect.ReflectHelper
-import org.apache.spark.{SparkConf, SparkCoreVersion, SparkRuntimeOperator, WowFastSparkContext}
 import org.apache.spark.ps.cluster.PSDriverBackend
 import org.apache.spark.ps.local.LocalPSSchedulerBackend
 import org.apache.spark.sql.{SQLContext, SparkSession}
 import streaming.common.ScalaObjectReflect
 import streaming.core.StreamingproJobManager
 import streaming.session.{SessionIdentifier, SessionManager}
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkRuntimeOperator
+import org.apache.spark.CarbonCoreVersion
+import org.apache.spark.WowFastSparkContext
+import org.apache.spark.SparkCoreVersion
 
 import scala.collection.JavaConversions._
 
@@ -87,11 +91,17 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
       sparkSession.enableHiveSupport()
     }
 
+    val checkCarbonDataCoreCompatibility = CarbonCoreVersion.coreCompatibility(SparkCoreVersion.version, SparkCoreVersion.exactVersion)
+    val isCarbonDataEnabled = params.containsKey("streaming.enableCarbonDataSupport") &&
+      params.get("streaming.enableCarbonDataSupport").toString.toBoolean && checkCarbonDataCoreCompatibility
 
-    val ss = if (params.containsKey("streaming.enableCarbonDataSupport") &&
-      params.get("streaming.enableCarbonDataSupport").toString.toBoolean) {
+    if (!checkCarbonDataCoreCompatibility) {
+      logger.warning(s"------- CarbonData do not support current version of spark [${SparkCoreVersion.exactVersion}], streaming.enableCarbonDataSupport will not take effect.--------")
+    }
 
-      logger.info("carbondata enabled...")
+    val ss = if (isCarbonDataEnabled) {
+
+      logger.info("CarbonData enabled...")
       val url = params.getOrElse("streaming.hive.javax.jdo.option.ConnectionURL", "").toString
       if (!url.isEmpty) {
         logger.info("set hive javax.jdo.option.ConnectionURL=" + url)
@@ -113,9 +123,6 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
       sparkSession.getOrCreate()
     }
 
-    //    if (params.getOrDefault("streaming.deploy.rest.api", "false").toString.toBoolean) {
-    //      WowFastLocalBasedStrategies.register(ss)
-    //    }
 
     if (params.containsKey("streaming.spark.service") && params.get("streaming.spark.service").toString.toBoolean) {
       StreamingproJobManager.init(ss.sparkContext)

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/python/APIPredict.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/python/APIPredict.scala
@@ -94,14 +94,17 @@ class APIPredict extends Logging with WowLog with Serializable {
     def coreVersion = {
       if (SparkCoreVersion.is_2_2_X) {
         "22"
-      } else if (SparkCoreVersion.exactVersion == "2.3.2") {
+      } else if (SparkCoreVersion.is_2_3_2()) {
         "232"
       }
-      else if (SparkCoreVersion.is_2_3_X) {
+      else if (SparkCoreVersion.is_2_3_1()) {
         "23"
-      } else {
+      } else if (SparkCoreVersion.is_2_4_X()) {
         "24"
+      } else {
+        throw new RuntimeException(s"No such spark version ${SparkCoreVersion.exactVersion}")
       }
+
     }
 
     val customDeamon = true

--- a/streamingpro-mlsql/src/test/scala/streaming/core/BasicMLSQLConfig.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/core/BasicMLSQLConfig.scala
@@ -11,7 +11,7 @@ trait BasicMLSQLConfig {
     "-streaming.platform", "spark",
     "-streaming.enableHiveSupport", "true",
     "-streaming.spark.service", "false",
-    "-streaming.udf.clzznames", "streaming.crawler.udf.Functions,streaming.dsl.mmlib.algs.processing.UDFFunctions",
+    "-streaming.udf.clzznames", "streaming.crawler.udf.Functions",
     "-streaming.unittest", "true"
   )
 
@@ -23,7 +23,7 @@ trait BasicMLSQLConfig {
     "-streaming.platform", "spark",
     "-streaming.enableHiveSupport", "true",
     "-streaming.spark.service", "false",
-    "-streaming.udf.clzznames", "streaming.crawler.udf.Functions,streaming.dsl.mmlib.algs.processing.UDFFunctions",
+    "-streaming.udf.clzznames", "streaming.crawler.udf.Functions",
     "-streaming.unittest", "true"
   )
 
@@ -35,7 +35,7 @@ trait BasicMLSQLConfig {
     "-streaming.platform", "spark",
     "-streaming.enableHiveSupport", "true",
     "-streaming.spark.service", "false",
-    "-streaming.udf.clzznames", "streaming.crawler.udf.Functions,streaming.dsl.mmlib.algs.processing.UDFFunctions",
+    "-streaming.udf.clzznames", "streaming.crawler.udf.Functions",
     "-streaming.unittest", "true",
     "-streaming.deploy.rest.api", "true"
   )
@@ -49,7 +49,7 @@ trait BasicMLSQLConfig {
     "-streaming.spark.service", "false",
     "-streaming.unittest", "true",
     "-streaming.enableCarbonDataSupport", "true",
-    "-streaming.udf.clzznames", "streaming.crawler.udf.Functions,streaming.dsl.mmlib.algs.processing.UDFFunctions",
+    "-streaming.udf.clzznames", "streaming.crawler.udf.Functions",
     "-streaming.carbondata.store", "/tmp/carbondata/store",
     "-streaming.carbondata.meta", "/tmp/carbondata/meta"
   )

--- a/streamingpro-mlsql/src/test/scala/streaming/test/carbondata/CarbonIntergrationSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/carbondata/CarbonIntergrationSpec.scala
@@ -10,26 +10,41 @@ import streaming.dsl.template.TemplateMerge
 /**
   * Created by allwefantasy on 12/9/2018.
   */
-class CarbonIntergrationSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig{
+class CarbonIntergrationSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig {
 
   "script-support-drop" should "work fine" taggedAs (NotToRunTag) in {
 
-    withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
+    withBatchContext(setupBatchContext(batchParamsWithCarbondata, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
       //执行sql
       implicit val spark = runtime.sparkSession
 
       val tableName = "visit_carbon5"
+      var sql =
+        """
+          |select "1" as a
+          |as mtf1;
+          |
+          |save overwrite mtf1
+          |as carbondata.`-`
+          |options mode="overwrite"
+          |and tableName="${tableName}"
+          |and implClass="org.apache.spark.sql.CarbonSource";
+        """.stripMargin
 
       var sq = createSSEL
 
-      ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("mlsql-carbondata"), Map("tableName" -> tableName)), sq)
-      Thread.sleep(1000)
+      ScriptSQLExec.parse(TemplateMerge.merge(sql, Map("tableName" -> tableName)), sq)
       val res = spark.sql("select * from " + tableName).toJSON.collect()
       val keyRes = JSONObject.fromObject(res(0)).getString("a")
       assume(keyRes == "1")
 
+      sql =
+        """
+          |drop table ${tableName};
+        """.stripMargin
+
       sq = createSSEL
-      ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("script-support-drop"), Map("tableName" -> tableName)), sq)
+      ScriptSQLExec.parse(TemplateMerge.merge(sql, Map("tableName" -> tableName)), sq)
       try {
         spark.sql("select * from " + tableName).toJSON.collect()
         assume(0 == 1)

--- a/streamingpro-mlsql/src/test/scala/streaming/test/carbondata/CarbonIntergrationSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/carbondata/CarbonIntergrationSpec.scala
@@ -1,6 +1,7 @@
 package streaming.test.carbondata
 
 import net.sf.json.JSONObject
+import org.apache.spark.{CarbonCoreVersion, SparkCoreVersion}
 import org.apache.spark.streaming.BasicSparkOperation
 import streaming.core.strategy.platform.SparkRuntime
 import streaming.core.{BasicMLSQLConfig, NotToRunTag, SpecFunctions}
@@ -12,78 +13,83 @@ import streaming.dsl.template.TemplateMerge
   */
 class CarbonIntergrationSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig {
 
-  "script-support-drop" should "work fine" taggedAs (NotToRunTag) in {
+  val checkCarbonDataCoreCompatibility = CarbonCoreVersion.coreCompatibility(SparkCoreVersion.version, SparkCoreVersion.exactVersion)
+
+  "script-support-drop" should "work fine" in {
 
     withBatchContext(setupBatchContext(batchParamsWithCarbondata, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
       //执行sql
       implicit val spark = runtime.sparkSession
+      if (checkCarbonDataCoreCompatibility) {
+        val tableName = "visit_carbon5"
+        var sql =
+          """
+            |select "1" as a
+            |as mtf1;
+            |
+            |save overwrite mtf1
+            |as carbondata.`-`
+            |options mode="overwrite"
+            |and tableName="${tableName}"
+            |and implClass="org.apache.spark.sql.CarbonSource";
+          """.stripMargin
 
-      val tableName = "visit_carbon5"
-      var sql =
-        """
-          |select "1" as a
-          |as mtf1;
-          |
-          |save overwrite mtf1
-          |as carbondata.`-`
-          |options mode="overwrite"
-          |and tableName="${tableName}"
-          |and implClass="org.apache.spark.sql.CarbonSource";
-        """.stripMargin
+        var sq = createSSEL
 
-      var sq = createSSEL
+        ScriptSQLExec.parse(TemplateMerge.merge(sql, Map("tableName" -> tableName)), sq)
+        val res = spark.sql("select * from " + tableName).toJSON.collect()
+        val keyRes = JSONObject.fromObject(res(0)).getString("a")
+        assume(keyRes == "1")
 
-      ScriptSQLExec.parse(TemplateMerge.merge(sql, Map("tableName" -> tableName)), sq)
-      val res = spark.sql("select * from " + tableName).toJSON.collect()
-      val keyRes = JSONObject.fromObject(res(0)).getString("a")
-      assume(keyRes == "1")
+        sql =
+          """
+            |drop table ${tableName};
+          """.stripMargin
 
-      sql =
-        """
-          |drop table ${tableName};
-        """.stripMargin
-
-      sq = createSSEL
-      ScriptSQLExec.parse(TemplateMerge.merge(sql, Map("tableName" -> tableName)), sq)
-      try {
-        spark.sql("select * from " + tableName).toJSON.collect()
-        assume(0 == 1)
-      } catch {
-        case e: Exception =>
+        sq = createSSEL
+        ScriptSQLExec.parse(TemplateMerge.merge(sql, Map("tableName" -> tableName)), sq)
+        try {
+          spark.sql("select * from " + tableName).toJSON.collect()
+          assume(0 == 1)
+        } catch {
+          case e: Exception =>
+        }
       }
+
 
     }
   }
-  "carbondata save" should "work fine" taggedAs (NotToRunTag) in {
+  "carbondata save" should "work fine" in {
 
     withBatchContext(setupBatchContext(batchParamsWithCarbondata, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
-      //执行sql
-      implicit val spark = runtime.sparkSession
-      var sq = createSSEL
-      var tableName = "visit_carbon3"
+      if (checkCarbonDataCoreCompatibility) {
+        //执行sql
+        implicit val spark = runtime.sparkSession
+        var sq = createSSEL
+        var tableName = "visit_carbon3"
 
-      dropTables(Seq(tableName))
+        dropTables(Seq(tableName))
 
-      ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("mlsql-carbondata"), Map("tableName" -> tableName)), sq)
-      Thread.sleep(1000)
-      var res = spark.sql("select * from " + tableName).toJSON.collect()
-      var keyRes = JSONObject.fromObject(res(0)).getString("a")
-      assume(keyRes == "1")
+        ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("mlsql-carbondata"), Map("tableName" -> tableName)), sq)
+        Thread.sleep(1000)
+        var res = spark.sql("select * from " + tableName).toJSON.collect()
+        var keyRes = JSONObject.fromObject(res(0)).getString("a")
+        assume(keyRes == "1")
 
-      dropTables(Seq(tableName))
+        dropTables(Seq(tableName))
 
-      sq = createSSEL
-      tableName = "visit_carbon4"
+        sq = createSSEL
+        tableName = "visit_carbon4"
 
-      dropTables(Seq(tableName))
+        dropTables(Seq(tableName))
 
-      ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("mlsql-carbondata-without-option"), Map("tableName" -> tableName)), sq)
-      Thread.sleep(1000)
-      res = spark.sql("select * from " + tableName).toJSON.collect()
-      keyRes = JSONObject.fromObject(res(0)).getString("a")
-      assume(keyRes == "1")
-      dropTables(Seq(tableName))
-
+        ScriptSQLExec.parse(TemplateMerge.merge(loadSQLScriptStr("mlsql-carbondata-without-option"), Map("tableName" -> tableName)), sq)
+        Thread.sleep(1000)
+        res = spark.sql("select * from " + tableName).toJSON.collect()
+        keyRes = JSONObject.fromObject(res(0)).getString("a")
+        assume(keyRes == "1")
+        dropTables(Seq(tableName))
+      }
     }
   }
 


### PR DESCRIPTION
#686  upgrade carbondata to 1.5.0.
Cause Carbondata do not support spark2.3.2,spark 2.4.0  ,  if we runs on the version CarbonData do not support, MLSQL will just ignore the enableCarbondata parameters.