### PR TITLE
[DEV][fix] fix start-local.sh script bug.

### DIFF
--- a/dev/start-local.sh
+++ b/dev/start-local.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 for env in SPARK_HOME ; do
   if [ -z "${!env}" ]; then
@@ -12,7 +13,7 @@ if [ -z "${MLSQL_HOME}" ]; then
 fi
 
 JARS=$(echo ${MLSQL_HOME}/libs/*.jar | tr ' ' ',')
-MAIN_AJR=$(ls libs|grep 'streamingpro-mlsql')
+MAIN_JAR=$(ls ${MLSQL_HOME}/libs|grep 'streamingpro-mlsql')
 $SPARK_HOME/bin/spark-submit --class streaming.core.StreamingApp \
         --jars ${JARS} \
         --master local[*] \
@@ -22,7 +23,7 @@ $SPARK_HOME/bin/spark-submit --class streaming.core.StreamingApp \
         --conf "spark.kryoserializer.buffer.max=1024m" \
         --conf "spark.serializer=org.apache.spark.serializer.KryoSerializer" \
         --conf "spark.scheduler.mode=FAIR" \
-        ${MLSQL_HOME}/libs/${MAIN_AJR}    \
+        ${MLSQL_HOME}/libs/${MAIN_JAR}    \
         -streaming.name mlsql    \
         -streaming.platform spark   \
         -streaming.rest true   \


### PR DESCRIPTION


# What changes were proposed in this pull request?
When we run the start-local.sh script in a different path than the `${MLSQL_HOME}` , it throw IllegalArgumentException. 

# How was this patch tested?
N/A

# Spark Core Compatibility
N/A