### PR TITLE
Issue 706

### DIFF
--- a/streamingpro-mlsql/pom.xml
+++ b/streamingpro-mlsql/pom.xml
@@ -360,11 +360,6 @@
             <artifactId>streamingpro-spark-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        <dependency>
-            <groupId>streaming.king</groupId>
-            <artifactId>streamingpro-tensorflow</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>streaming.king</groupId>

--- a/streamingpro-mlsql/src/test/scala/streaming/test/stream/StreamSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/stream/StreamSpec.scala
@@ -2,25 +2,43 @@ package streaming.test.stream
 
 import org.apache.spark.SparkCoreVersion
 import org.apache.spark.streaming.BasicSparkOperation
+import org.scalatest.BeforeAndAfterAll
 import streaming.common.shell.ShellCommand
 import streaming.core.strategy.platform.SparkRuntime
 import streaming.core.{BasicMLSQLConfig, SpecFunctions}
 import streaming.dsl.ScriptSQLExec
 
-class StreamSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig {
+class StreamSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig with BeforeAndAfterAll {
+  val KAFKA_0_8_HOME = System.getenv("KAFKA_0_8_HOME")
+
   "kafka8/kafka9" should "work fine on spark 2.3.x" in {
     withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
       //执行sql
       implicit val spark = runtime.sparkSession
-      val kafkaHome = System.getenv("KAFKA_HOME")
-      if (SparkCoreVersion.is_2_3_2() && kafkaHome != null) {
-        val ssel = createSSEL
-        ShellCommand.execCmd("rm -rf /tmp/cpl3")
-        // check kafka if exists
+      // we suppose that if KAFKA_HOME is configured ,then there must be a kafka server exists
+      if (SparkCoreVersion.is_2_3_2() && KAFKA_0_8_HOME != null) {
 
-        //        if (kafkaHome != null) {
-        //          ShellCommand.execCmd("cd $KAFKA_HOME;./bin/kafka-server-start.sh  -daemon config/server.properties")
-        //        }
+        ShellCommand.execCmd("rm -rf /tmp/cpl3")
+
+        new Thread(new Runnable {
+          override def run(): Unit = {
+            var count = 20
+            while (count > 0) {
+              val ssel = createSSEL
+              ScriptSQLExec.parse(
+                """
+                  |select "a" as a as tmp_table1;
+                  |save append tmp_table1
+                  |as kafka8.`test_cool` where metadata.broker.list="127.0.0.1:9092";
+                """.stripMargin, ssel)
+              Thread.sleep(1000)
+              count -= 1
+            }
+
+          }
+        }).start()
+
+        val ssel = createSSEL
         ScriptSQLExec.parse(
           """
             |set streamName="streamExample";
@@ -37,5 +55,21 @@ class StreamSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLC
         Thread.sleep(1000 * 30)
       }
     }
+  }
+
+  override protected def beforeAll(): Unit = {
+    if (KAFKA_0_8_HOME != null) {
+      val res = ShellCommand.exec("cd $KAFKA_0_8_HOME;./bin/kafka-server-start.sh -daemon config/server.properties")
+      println(res)
+      Thread.sleep(20 * 1000)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    if (KAFKA_0_8_HOME != null) {
+      val res = ShellCommand.exec("cd $KAFKA_0_8_HOME;./bin/kafka-server-stop.sh")
+      println(res)
+    }
+
   }
 }

--- a/streamingpro-mlsql/src/test/scala/streaming/test/stream/StreamSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/stream/StreamSpec.scala
@@ -1,0 +1,41 @@
+package streaming.test.stream
+
+import org.apache.spark.SparkCoreVersion
+import org.apache.spark.streaming.BasicSparkOperation
+import streaming.common.shell.ShellCommand
+import streaming.core.strategy.platform.SparkRuntime
+import streaming.core.{BasicMLSQLConfig, SpecFunctions}
+import streaming.dsl.ScriptSQLExec
+
+class StreamSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig {
+  "kafka8/kafka9" should "work fine on spark 2.3.x" in {
+    withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
+      //执行sql
+      implicit val spark = runtime.sparkSession
+      val kafkaHome = System.getenv("KAFKA_HOME")
+      if (SparkCoreVersion.is_2_3_2() && kafkaHome != null) {
+        val ssel = createSSEL
+        ShellCommand.execCmd("rm -rf /tmp/cpl3")
+        // check kafka if exists
+
+        //        if (kafkaHome != null) {
+        //          ShellCommand.execCmd("cd $KAFKA_HOME;./bin/kafka-server-start.sh  -daemon config/server.properties")
+        //        }
+        ScriptSQLExec.parse(
+          """
+            |set streamName="streamExample";
+            |load kafka8.`` options kafka.bootstrap.servers="127.0.0.1:9092"
+            |and `topics`="test_cool"
+            |as table1;
+            |
+            |save append table1
+            |as console.``
+            |options mode="Append"
+            |and duration="2"
+            |and checkpointLocation="/tmp/cpl3";
+          """.stripMargin, ssel)
+        Thread.sleep(1000 * 30)
+      }
+    }
+  }
+}

--- a/streamingpro-spark-2.2.0-adaptor/pom.xml
+++ b/streamingpro-spark-2.2.0-adaptor/pom.xml
@@ -23,11 +23,6 @@
             <version>${project.parent.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>streaming.king</groupId>
-            <artifactId>streamingpro-tensorflow</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/sql/SessionWrapper.scala
+++ b/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/sql/SessionWrapper.scala
@@ -1,0 +1,13 @@
+package org.apache.spark.sql
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.StructType
+
+class SessionWrapper(sparkSession: SparkSession) {
+  def internalCreateDataFrame(catalystRows: RDD[InternalRow],
+                              schema: StructType,
+                              isStreaming: Boolean = false) = {
+    sparkSession.sqlContext.internalCreateDataFrame(catalystRows, schema)
+  }
+}

--- a/streamingpro-spark-2.3.0-adaptor/pom.xml
+++ b/streamingpro-spark-2.3.0-adaptor/pom.xml
@@ -24,12 +24,6 @@
         </dependency>
 
         <dependency>
-            <groupId>streaming.king</groupId>
-            <artifactId>streamingpro-tensorflow</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>

--- a/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/sql/SessionWrapper.scala
+++ b/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/sql/SessionWrapper.scala
@@ -1,0 +1,13 @@
+package org.apache.spark.sql
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.StructType
+
+class SessionWrapper(sparkSession: SparkSession) {
+  def internalCreateDataFrame(catalystRows: RDD[InternalRow],
+                              schema: StructType,
+                              isStreaming: Boolean = false) = {
+    sparkSession.sqlContext.internalCreateDataFrame(catalystRows, schema, isStreaming = true)
+  }
+}

--- a/streamingpro-spark-2.4.0-adaptor/pom.xml
+++ b/streamingpro-spark-2.4.0-adaptor/pom.xml
@@ -24,11 +24,6 @@
             <version>${project.parent.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>streaming.king</groupId>
-            <artifactId>streamingpro-tensorflow</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/sql/SessionWrapper.scala
+++ b/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/sql/SessionWrapper.scala
@@ -1,0 +1,13 @@
+package org.apache.spark.sql
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.StructType
+
+class SessionWrapper(sparkSession: SparkSession) {
+  def internalCreateDataFrame(catalystRows: RDD[InternalRow],
+                              schema: StructType,
+                              isStreaming: Boolean = false) = {
+    sparkSession.sqlContext.internalCreateDataFrame(catalystRows, schema, isStreaming = true)
+  }
+}


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [x] MLSQL stream supports Kafka 0.8.x/0.9.x  in Spark 2.3.x
- [x] MLSQL stream supports Kafka 0.8.x/0.9.x  in Spark 2.4.x
- [x] MLSQL stream supports Kafka 0.8.x/0.9.x  in Spark 2.2.x 

# How was this patch tested?
- [x] streaming.test.stream.StreamSpec

# Spark Core Compatibility
Spark 2.2.x,Spark 2.3.x,Spark 2.4.x