### PR TITLE
fix skipAuth equals false ,include not match excepiton

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/ScriptSQLExec.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/ScriptSQLExec.scala
@@ -79,11 +79,11 @@ object ScriptSQLExec extends Logging with WowLog {
       val sqel = listener.asInstanceOf[ScriptSQLExecListener]
       val setListener = new PreProcessSetListener(sqel._sparkSession, sqel._defaultPathPrefix, sqel._allPathPrefix)
       sqel.setProcessListner = Some(setListener)
-      _parse(input, setListener)
+      _parse(wow, setListener)
       // setListener.env()
       val authListener = new AuthProcessListener(setListener)
       sqel.authProcessListner = Some(authListener)
-      _parse(input, authListener)
+      _parse(wow, authListener)
       val tableAuth = Class.forName(authListener.listener.env().getOrElse("__auth_client__", "streaming.dsl.auth.meta.client.DefaultConsoleClient")).newInstance().asInstanceOf[TableAuth]
       tableAuth.auth(authListener.tables().tables.toList)
     }

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/auth/meta/client/DefaultConsoleClient.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/auth/meta/client/DefaultConsoleClient.scala
@@ -11,6 +11,10 @@ class DefaultConsoleClient extends TableAuth with Logging with WowLog {
   override def auth(tables: List[MLSQLTable]): List[TableAuthResult] = {
     val owner = ScriptSQLExec.contextGetOrForTest().owner
     logInfo(format(s"auth ${owner}  want access tables: ${tables.mkString(",")}"))
-    throw new RuntimeException("auth fail")
+    if (owner == "william"){
+      throw new RuntimeException("auth fail")
+    }else{
+      List(TableAuthResult(true ,""))
+    }
   }
 }

--- a/streamingpro-mlsql/src/main/resources-local/test/include-set.txt
+++ b/streamingpro-mlsql/src/main/resources-local/test/include-set.txt
@@ -1,0 +1,1 @@
+set xx="latincross";

--- a/streamingpro-mlsql/src/main/resources-online/test/include-set.txt
+++ b/streamingpro-mlsql/src/main/resources-online/test/include-set.txt
@@ -1,0 +1,1 @@
+set xx="latincross";


### PR DESCRIPTION
# What changes were proposed in this pull request?
#756 
fix skipAuth equals false ,ScriptSQLExec bug
- [x] Finshed changes describe

# How was this patch tested?
`streaming.test.rest.RestAPISpec`,test case `/run/script auth`
- [x] Testing done

# Spark Core Compatibility
All