### PR TITLE
In general , it is better to add -DskipTests for compile guide

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -5,7 +5,7 @@
 ```
 git clone https://github.com/allwefantasy/ServiceFramework.git
 cd ServiceFramework
-mvn install -Pscala-2.11 -Pjetty-9 -Pweb-include-jetty-9
+mvn install -DskipTests -Pscala-2.11 -Pjetty-9 -Pweb-include-jetty-9
 ```
 
 


### PR DESCRIPTION
In general, it is better to add -DskipTests for compile guide for avoiding test cases failure

For a new user, first just want to try this project, so the compile guide doesn't need to run test cases.
by the way,  there are some test cases failed in ServiceFramework.git

# What changes were proposed in this pull request?
- [x] Finshed changes describe

# How was this patch tested?
- [x] Testing done
NA
# Spark Core Compatibility
