### PR TITLE
[PSCluster][add] add ping/pong test method for ps cluster debug!

### DIFF
--- a/contri/streamingpro-automl/pom.xml
+++ b/contri/streamingpro-automl/pom.xml
@@ -16,6 +16,12 @@
             <groupId>com.salesforce.transmogrifai</groupId>
             <artifactId>transmogrifai-core_2.11</artifactId>
             <version>0.3.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.optimaize.languagedetector</groupId>
+                    <artifactId>language-detector</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.optimaize.languagedetector</groupId>

--- a/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -87,7 +87,7 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
            |for exmaple:
            |
            |--jars ./streamingpro-mlsql-spark_2.x-x.x.x-SNAPSHOT.jar
-           |--conf "spark.executor.extraClassPath=streamingpro-mlsql-spark_2.x-x.x.x-SNAPSHOT.jar" 
+           |--conf "spark.executor.extraClassPath=streamingpro-mlsql-spark_2.x-x.x.x-SNAPSHOT.jar"
            |
            |Otherwise the executor will
            |fail to start and the whole application will fails.

--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
@@ -481,6 +481,13 @@ class RestController extends ApplicationController {
     render(s"""{"msg":${res}""")
   }
 
+  @At(path = Array("/debug/executor/ping"), types = Array(GET, POST))
+  def pingExecuotrs = {
+    val psDriverBackend = runtime.asInstanceOf[SparkRuntime].psDriverBackend
+    psDriverBackend.psDriverRpcEndpointRef.ask(Message.Ping)
+    render("{}")
+  }
+
   @At(path = Array("/instance/resource"), types = Array(GET, POST))
   def instanceResource = {
     val session = runtime.asInstanceOf[SparkRuntime].sparkSession

--- a/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/ps/cluster/Message.scala
+++ b/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/ps/cluster/Message.scala
@@ -25,4 +25,8 @@ object Message {
 
   case class CopyModelToLocal(modelPath: String, destPath: String)
 
+  case object Ping
+
+  case class Pong(executorId: String)
+
 }

--- a/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
+++ b/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
@@ -52,6 +52,9 @@ class PSExecutorBackend(env: SparkEnv, override val rpcEnv: RpcEnv, psDriverUrl:
       HDFSOperator.copyToLocalFile(destPath, modelPath, true)
       context.reply(true)
     }
+    case Message.Ping =>
+      logInfo(s"received message ${Message.Ping}")
+      context.reply(Message.Pong(psExecutorId))
   }
 }
 

--- a/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/ps/cluster/Message.scala
+++ b/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/ps/cluster/Message.scala
@@ -25,4 +25,8 @@ object Message {
 
   case class CopyModelToLocal(modelPath: String, destPath: String)
 
+  case object Ping
+
+  case class Pong(executorId: String)
+
 }

--- a/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
+++ b/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
@@ -52,6 +52,9 @@ class PSExecutorBackend(env: SparkEnv, override val rpcEnv: RpcEnv, psDriverUrl:
       HDFSOperator.copyToLocalFile(destPath, modelPath, true)
       context.reply(true)
     }
+    case Message.Ping =>
+      logInfo(s"received message ${Message.Ping}")
+      context.reply(Message.Pong(psExecutorId))
   }
 }
 

--- a/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/ps/cluster/Message.scala
+++ b/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/ps/cluster/Message.scala
@@ -25,4 +25,8 @@ object Message {
 
   case class CopyModelToLocal(modelPath: String, destPath: String)
 
+  case object Ping
+
+  case class Pong(executorId: String)
+
 }

--- a/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
+++ b/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
@@ -52,6 +52,9 @@ class PSExecutorBackend(env: SparkEnv, override val rpcEnv: RpcEnv, psDriverUrl:
       HDFSOperator.copyToLocalFile(destPath, modelPath, true)
       context.reply(true)
     }
+    case Message.Ping =>
+      logInfo(s"received message ${Message.Ping}")
+      context.reply(Message.Pong(psExecutorId))
   }
 }
 


### PR DESCRIPTION
# What changes were proposed in this pull request?
- add ping/pong test method for ps cluster debug!
visit `/debug/executor/ping`, the spark driver will send `Ping` message to executors. and then executor response with Message `Pong(executorId)`. this is useful for ps cluster test.

# How was this patch tested?
N/A

# Spark Core Compatibility
- [x] ALL