### PR TITLE
[PSCluster][update] use the same config keyword `streaming.ps.enable`…

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/strategy/platform/SparkRuntime.scala
@@ -75,11 +75,11 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
       conf.setIfMissing("spark.speculation", "false")
     }
 
-    if (MLSQLConf.MLSQL_CLUSTER_PS_ENABLE.readFrom(configReader) && !isLocalMaster(conf)) {
+    if (MLSQLConf.MLSQL_PS_ENABLE.readFrom(configReader) && !isLocalMaster(conf)) {
       logWarning(
         s"""
            |------------------------------------------------------------------------
-           |${MLSQLConf.MLSQL_CLUSTER_PS_ENABLE.key} is enabled. Please make sure
+           |in cluster run mode, ${MLSQLConf.MLSQL_PS_ENABLE.key} is enabled. Please make sure
            |you have the uber-jar of mlsql placed in
            |1. --jars
            |2. --conf "spark.executor.extraClassPath=[your jar name in jars]"
@@ -157,13 +157,13 @@ class SparkRuntime(_params: JMap[Any, Any]) extends StreamingRuntime with Platfo
 
     // parameter server should be enabled by default
 
-    if (MLSQLConf.MLSQL_LOCAL_PS_ENABLE.readFrom(configReader) && isLocalMaster(conf)) {
+    if (MLSQLConf.MLSQL_PS_ENABLE.readFrom(configReader) && isLocalMaster(conf)) {
       logInfo("start LocalPSSchedulerBackend")
       localSchedulerBackend = new LocalPSSchedulerBackend(ss.sparkContext)
       localSchedulerBackend.start()
     }
 
-    if (MLSQLConf.MLSQL_CLUSTER_PS_ENABLE.readFrom(configReader) && !isLocalMaster(conf)) {
+    if (MLSQLConf.MLSQL_PS_ENABLE.readFrom(configReader) && !isLocalMaster(conf)) {
       logInfo("start PSDriverBackend")
       psDriverBackend = new PSDriverBackend(ss.sparkContext)
       psDriverBackend.start()

--- a/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/MLSQLConf.scala
+++ b/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/MLSQLConf.scala
@@ -57,15 +57,10 @@ object MLSQLConf {
         |  conf.setIfMissing("spark.speculation", "false")
       """.stripMargin).booleanConf.createWithDefault(true)
 
-  val MLSQL_LOCAL_PS_ENABLE: ConfigEntry[Boolean] = MLSQLConfigBuilder("streaming.ps.local.enable").doc(
+  val MLSQL_PS_ENABLE: ConfigEntry[Boolean] = MLSQLConfigBuilder("streaming.ps.enable").doc(
     """
       |MLSQL supports directly communicating with executor if you set this true.
     """.stripMargin).booleanConf.createWithDefault(true)
-
-  val MLSQL_CLUSTER_PS_ENABLE: ConfigEntry[Boolean] = MLSQLConfigBuilder("streaming.ps.cluster.enable").doc(
-    """
-      |MLSQL supports directly communicating with executor if you set this true.
-    """.stripMargin).booleanConf.createWithDefault(false)
 
   val MLSQL_CLUSTER_PS_DRIVER_PORT: ConfigEntry[Int] = MLSQLConfigBuilder("spark.ps.cluster.driver.port").doc(
     """


### PR DESCRIPTION
… for local and cluster mode.

# What changes were proposed in this pull request?
- [x] using the same config keyword `streaming.ps.enable` for local and cluster mode.

# How was this patch tested?
- [x] N/A

# Spark Core Compatibility
- [x] ALL