### PR TITLE
fix load es index contains . bug

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/DslAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/DslAdaptor.scala
@@ -79,9 +79,9 @@ trait DslTool {
     withPathPrefix(context.home, path)
   }
 
-  def parseDBAndTableFromStr(str: String) = {
+  def parseDBAndTableFromStr(str: String  ,separator: String = "\\.") = {
     val cleanedStr = cleanStr(str)
-    val dbAndTable = cleanedStr.split("\\.")
+    val dbAndTable = cleanedStr.split(separator)
     if (dbAndTable.length > 1) {
       val db = dbAndTable(0)
       val table = dbAndTable.splitAt(1)._2.mkString(".")


### PR DESCRIPTION
# What changes were proposed in this pull request?
#801
- [x] Finshed changes describe

# How was this patch tested?
```
load es.`/.people.abc.index` options `es.nodes`="127.0.0.1"
and `es.port`="9200"
as es_test;

load es.`.people.abc.index` options `es.nodes`="127.0.0.1"
and `es.port`="9200"
as es_test;

load es.`people/man` options `es.nodes`="127.0.0.1"
and `es.port`="9200"
as es_test;

connect es where
`es.nodes`="127.0.0.1"
and `es.port`="9200"
and `es.resource`=".people.abc.index"
as es_conn;

load es.`es_conn.man`
as es_test;
```
- [x] Testing done

# Spark Core Compatibility