### PR TITLE
datasource support solrcloud

### DIFF
--- a/streamingpro-api/src/main/java/streaming/dsl/auth/Protocal.scala
+++ b/streamingpro-api/src/main/java/streaming/dsl/auth/Protocal.scala
@@ -56,12 +56,13 @@ object TableType {
   val JDBC = TableTypeMeta("jdbc", Set("jdbc"))
   val ES = TableTypeMeta("es", Set("es"))
   val MONGO = TableTypeMeta("mongo", Set("mongo"))
+  val SOLR = TableTypeMeta("solr", Set("solr"))
   val TEMP = TableTypeMeta("temp", Set("temp", "jsonStr" ,"script"))
   val API = TableTypeMeta("api", Set("mlsqlAPI", "mlsqlConf"))
   val WEB = TableTypeMeta("web", Set("crawlersql"))
 
   def from(str: String) = {
-    List(HIVE, HBASE, HDFS, HTTP, JDBC, ES, MONGO, TEMP ,API ,WEB).filter(f => f.includes.contains(str)).headOption
+    List(HIVE, HBASE, HDFS, HTTP, JDBC, ES, MONGO, SOLR, TEMP ,API ,WEB).filter(f => f.includes.contains(str)).headOption
   }
 }
 

--- a/streamingpro-mlsql/pom.xml
+++ b/streamingpro-mlsql/pom.xml
@@ -262,6 +262,45 @@
                         
                     </exclusions>
                 </dependency>
+                <dependency>
+                    <groupId>com.lucidworks.spark</groupId>
+                    <artifactId>spark-solr</artifactId>
+                    <version>3.6.0</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-slf4j-impl</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-log4j12</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <artifactId>*</artifactId>
+                            <groupId>javax.servlet</groupId>
+                        </exclusion>
+                        <exclusion>
+                            <artifactId>*</artifactId>
+                            <groupId>org.apache.hadoop</groupId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-core</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-databind</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.module</groupId>
+                            <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.esotericsoftware</groupId>
+                            <artifactId>kryo-shaded</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
             </dependencies>
         </profile>
 

--- a/streamingpro-mlsql/src/main/java/streaming/core/datasource/impl/MLSQLSolr.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/datasource/impl/MLSQLSolr.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streaming.core.datasource.impl
+
+import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row}
+import streaming.core.datasource._
+import streaming.dsl.{ConnectMeta, DBMappingKey}
+
+class MLSQLSolr extends MLSQLSource with MLSQLSink with MLSQLSourceInfo with MLSQLRegistry {
+
+  override def fullFormat: String = "solr"
+
+  override def shortFormat: String = "solr"
+
+  override def dbSplitter: String = "/"
+
+  override def load(reader: DataFrameReader, config: DataSourceConfig): DataFrame = {
+
+    var dbtable = config.path
+    // if contains splitter, then we will try to find dbname in dbMapping.
+    val format = config.config.getOrElse("implClass", fullFormat)
+    if (config.path.contains(dbSplitter)) {
+      val Array(_dbname, _dbtable) = config.path.split(dbSplitter, 2)
+
+      ConnectMeta.presentThenCall(DBMappingKey(format, _dbname), options => {
+        dbtable = _dbtable
+        reader.options(options)
+      })
+    }
+
+    //load configs should overwrite connect configs
+    reader.options(config.config)
+    reader.format(format).load(dbtable)
+  }
+
+  override def save(writer: DataFrameWriter[Row], config: DataSinkConfig): Unit = {
+    var dbtable = config.path
+    // if contains splitter, then we will try to find dbname in dbMapping.
+
+    val format = config.config.getOrElse("implClass", fullFormat)
+    if (config.path.contains(dbSplitter)) {
+      val Array(_dbname, _dbtable) = config.path.split(dbSplitter, 2)
+      ConnectMeta.presentThenCall(DBMappingKey(format, _dbname), (options) => {
+        dbtable = _dbtable
+        writer.options(options)
+      })
+    }
+    writer.mode(config.mode)
+    //load configs should overwrite connect configs
+    writer.options(config.config)
+    config.config.get("partitionByCol").map { item =>
+      writer.partitionBy(item.split(","): _*)
+    }
+    writer.format(config.config.getOrElse("implClass", fullFormat)).save(dbtable)
+  }
+
+  override def register(): Unit = {
+    DataSourceRegistry.register(MLSQLDataSourceKey(shortFormat, MLSQLSparkDataSourceType), this)
+    DataSourceRegistry.register(MLSQLDataSourceKey(shortFormat, MLSQLSparkDataSourceType), this)
+  }
+
+  override def sourceInfo(config: DataAuthConfig): SourceInfo = {
+
+    val Array(_dbname, _dbtable) = if (config.path.contains(dbSplitter)) {
+      config.path.split(dbSplitter, 2)
+    } else {
+      Array("", config.path)
+    }
+
+    val db = if (config.config.contains("collection")) {
+      config.config.get("collection").get
+    } else {
+      val format = config.config.getOrElse("implClass", fullFormat)
+
+      ConnectMeta.options(DBMappingKey(format, _dbname)).get("collection")
+    }
+
+    SourceInfo(shortFormat, db, "")
+  }
+
+}

--- a/streamingpro-mlsql/src/test/scala/streaming/test/datasource/SolrSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/datasource/SolrSpec.scala
@@ -1,0 +1,58 @@
+package streaming.test.datasource
+
+import org.apache.spark.streaming.BasicSparkOperation
+import org.scalatest.BeforeAndAfterAll
+import streaming.core.strategy.platform.SparkRuntime
+import streaming.core.{BasicMLSQLConfig, SpecFunctions}
+import streaming.dsl.ScriptSQLExec
+import streaming.log.Logging
+
+/**
+  * Created by pigeongeng on 2018/12/27.4:19 PM
+  *
+  */
+class SolrSpec extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig with BeforeAndAfterAll with Logging {
+  "load solr" should "work fine" in {
+
+    withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
+
+      implicit val spark = runtime.sparkSession
+
+      var sq = createSSEL
+      ScriptSQLExec.parse(
+        s"""
+           |
+           |select 1 as id, "this is mlsql_example" as title_s as mlsql_example_data;
+           |
+           |connect solr where `zkhost`="127.0.0.1:9983"
+           |and `collection`="mlsql_example"
+           |and `flatten_multivalued`="false"
+           |as solr1
+           |;
+           |
+           |load solr.`solr1/mlsql_example` as mlsql_example;
+           |
+           |save mlsql_example_data as solr.`solr1/mlsql_example`
+           |options soft_commit_secs = "1";
+           |
+         """.stripMargin, sq)
+
+      //solr commit time is 1 secs,so need sleep
+      Thread.sleep(2000)
+
+      ScriptSQLExec.parse("load solr.`solr1/mlsql_example` as mlsql_example;", sq)
+
+      assume(spark.sql("select * from mlsql_example").collect().last.get(0) == "1")
+    }
+  }
+
+  val server = new streaming.test.servers.SolrServer()
+
+  override protected def beforeAll(): Unit = {
+    server.startServer
+  }
+
+  override protected def afterAll(): Unit = {
+    server.stopServer
+  }
+}

--- a/streamingpro-mlsql/src/test/scala/streaming/test/servers/SolrServer.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/servers/SolrServer.scala
@@ -1,0 +1,39 @@
+package streaming.test.servers
+
+
+/**
+  * Created by pigeongeng on 2018/12/27.4:55 PM
+  *
+  */
+class SolrServer(version: String= "latest") extends WowBaseTestServer {
+
+  override def composeYaml: String =
+    s"""
+       |version: '2'
+       |services:
+       |  solr:
+       |    image: solr
+       |    ports:
+       |      - "9983:9983"
+       |      - "8983:8983"
+       |    entrypoint:
+       |      - docker-entrypoint.sh
+       |      - solr
+       |      - start
+       |      - -f
+       |      - -h
+       |      - 127.0.0.1
+       |      - -noprompt
+       |      - -cloud
+    """.stripMargin
+
+  /**
+    * create a collection with the name mlsql_example
+    * check it is successful
+    * */
+  override def waitToServiceReady: Boolean = {
+    // wait mongo to ready, runs on host server
+    val shellCommand = s"curl 'http://localhost:8983/solr/admin/collections?action=CREATE&name=mlsql_example&numShards=1&replicationFactor=2&maxShardsPerNode=2&collection.configName=_default'"
+    readyCheck("", shellCommand, false)
+  }
+}


### PR DESCRIPTION
# What changes were proposed in this pull request?
+  we implement it using <a href="https://github.com/lucidworks/spark-solr" target="_blank">lucidworks/spark-solr</a>. so you need Import additional jar File via spark-shell
```
--jars spark-solr-3.6.0-shaded.jar
```
<a href="https://search.maven.org/remotecontent?filepath=com/lucidworks/spark/spark-solr/3.6.0/spark-solr-3.6.0-shaded.jar" target="_blank">download</a>

# How was this patch tested?

+ select
```
connect solr where `zkhost`="127.0.0.1:9983"
and `collection`="mlsql_example"
and `flatten_multivalued`="false"
as solr1
;

load solr.`solr1/mlsql_example` as mlsql_example;

select * from mlsql_example as data;
```

+ save
```
select 1 as id, "this is mlsql_example" as title_s as mlsql_example_data;
-- you need first create collection
connect solr where `zkhost`="127.0.0.1:9983"
and `collection`="mlsql_example"
and `flatten_multivalued`="false"
as solr1
;

load solr.`solr1/mlsql_example` as mlsql_example;

save mlsql_example_data as solr.`solr1/mlsql_example`
options soft_commit_secs = "1";
```
**notice** autoSoftCommit minimum is 1s. you store data to index, but data cannot be searched immediately.

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
+ please look <a href="https://github.com/lucidworks/spark-solr#version-compatibility" target="_blank">version-compatibility</a> 