### PR TITLE
include statement default implementation is set to `streaming.dsl.mml…

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/IncludeAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/IncludeAdaptor.scala
@@ -76,7 +76,13 @@ object IncludeAdaptor {
 
   def findAlg(format: String, options: Map[String, String]) = {
     val clzz = mapping.getOrElse(format, options.getOrElse("implClass", "streaming.dsl.mmlib.algs.includes." + format))
-    Class.forName(clzz).newInstance().asInstanceOf[IncludeSource]
+    val clzzInstance = try {
+      Class.forName(clzz)
+    } catch {
+      case e: Exception =>
+        Class.forName("streaming.dsl.mmlib.algs.includes.analyst.HttpBaseDirIncludeSource")
+    }
+    clzzInstance.newInstance().asInstanceOf[IncludeSource]
   }
 
 }


### PR DESCRIPTION
…ib.algs.includes.analyst.HttpBaseDirIncludeSource`

# What changes were proposed in this pull request?
- [x] Finshed changes describe

# How was this patch tested?
- [x] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
ALL