### PR TITLE
Provide PythonParallelExt which used to process data with python

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPythonParallelExt.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLPythonParallelExt.scala
@@ -1,0 +1,120 @@
+package streaming.dsl.mmlib.algs
+
+import org.apache.spark.ml.param.Param
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.mlsql.session.MLSQLException
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import streaming.common.HDFSOperator
+import streaming.dsl.ScriptSQLExec
+import streaming.dsl.mmlib.SQLAlg
+import streaming.dsl.mmlib.algs.param.BaseParams
+import streaming.dsl.mmlib.algs.python.PythonTrain
+
+
+/**
+  * 2019-01-08 WilliamZhu(allwefantasy@gmail.com)
+  */
+class SQLPythonParallelExt(override val uid: String) extends SQLAlg with Functions with BaseParams {
+  def this() = this(BaseParams.randomUID())
+
+  private def validateParams(params: Map[String, String]) = {
+    params.get(feedMode.name).map(item => set(feedMode, item))
+
+
+    params.get(scripts.name).map { item =>
+      set(scripts, item)
+      item
+    }.getOrElse {
+      throw new MLSQLException(s"${scripts.name} is required")
+    }
+
+    params.get(entryPoint.name).map { item =>
+      set(entryPoint, item)
+      item
+    }.getOrElse {
+      throw new MLSQLException(s"${entryPoint.name} is required")
+    }
+
+    params.get(condaFile.name).map { item =>
+      set(condaFile, item)
+      item
+    }.getOrElse {
+      throw new MLSQLException(s"${condaFile.name} is required")
+    }
+  }
+
+  def projectName = "mlsql-python-project"
+
+  /*
+     We will automatically create project for user according the configuration 
+   */
+  private def saveProject(sparkSession: SparkSession, path: String) = {
+    val projectPath = path + s"/${projectName}"
+    $(scripts).split(",").foreach { script =>
+      val content = sparkSession.table(script).head().getString(0)
+      HDFSOperator.saveFile(projectPath, script + ".py", Seq(("", content)).iterator)
+    }
+    HDFSOperator.saveFile(projectPath, "MLproject", Seq(("", MLprojectTemplate)).iterator)
+    val condaContent = sparkSession.table($(condaFile)).head().getString(0)
+    HDFSOperator.saveFile(projectPath, "conda.yaml", Seq(("", condaContent)).iterator)
+    projectPath
+  }
+
+
+  private def MLprojectTemplate = {
+    s"""
+       |name: mlsql-python
+       |
+       |conda_env: conda.yaml
+       |
+       |entry_points:
+       |  main:
+       |    train:
+       |        command: "python ${$(entryPoint)}.py"
+       |    batchPredict:
+       |        command: "python ${$(entryPoint)}.py"
+     """.stripMargin
+  }
+
+  override def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+
+    val mlsqlContext = ScriptSQLExec.contextGetOrForTest()
+
+    validateParams(params)
+
+    val projectPath = saveProject(df.sparkSession, path)
+
+    var newParams = params
+
+    newParams += ("enableDataLocal" -> ($(feedMode) == "file").toString)
+    newParams += ("pythonScriptPath" -> projectPath)
+    val pt = new PythonTrain()
+    pt.train_per_partition(df, path, newParams)
+
+  }
+
+  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = throw new MLSQLException("register is not support")
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = throw new MLSQLException("register is not support")
+
+  override def batchPredict(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    train(df, path, params)
+  }
+
+  final val feedMode: Param[String] = new Param(this, "feedMode",
+    "file/iterator")
+  setDefault(feedMode, "file")
+
+  final val scripts: Param[String] = new Param(this, "scripts",
+    "")
+
+  final val projectPath: Param[String] = new Param(this, "projectPath",
+    "")
+
+  final val entryPoint: Param[String] = new Param(this, "entryPoint",
+    "")
+
+  final val condaFile: Param[String] = new Param(this, "condaFile",
+    "")
+
+}

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/python/PythonTrain.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/python/PythonTrain.scala
@@ -20,22 +20,246 @@ package streaming.dsl.mmlib.algs.python
 
 import java.io.File
 import java.util
+import java.util.UUID
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
 import org.apache.spark.util._
-import streaming.dsl.mmlib.algs.SQLPythonFunc._
-
-import scala.collection.JavaConverters._
+import streaming.common.ScalaMethodMacros._
 import streaming.common.{HDFSOperator, NetUtils}
 import streaming.dsl.ScriptSQLExec
-import streaming.common.ScalaMethodMacros._
+import streaming.dsl.mmlib.algs.SQLPythonFunc._
 import streaming.dsl.mmlib.algs.{Functions, SQLPythonAlg, SQLPythonFunc}
 
+import scala.collection.JavaConverters._
+
 class PythonTrain extends Functions with Serializable {
+  def train_per_partition(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    val keepVersion = params.getOrElse("keepVersion", "false").toBoolean
+    val keepLocalDirectory = params.getOrElse("keepLocalDirectory", "false").toBoolean
+
+    var kafkaParam = mapParams("kafkaParam", params)
+
+    val enableDataLocal = params.getOrElse("enableDataLocal", "true").toBoolean
+
+    var stopFlagNum = -1
+    if (!enableDataLocal) {
+      require(kafkaParam.size > 0, "We detect that you do not set enableDataLocal true, " +
+        "in this situation, kafkaParam should be configured")
+      val (_kafkaParam, _newRDD) = writeKafka(df, path, params)
+      stopFlagNum = _newRDD.getNumPartitions
+      kafkaParam = _kafkaParam
+    }
+
+    // find python project
+    val pythonProject = PythonAlgProject.loadProject(params, df.sparkSession)
+    incrementVersion(path, keepVersion)
+
+    val mlsqlContext = ScriptSQLExec.contextGetOrForTest()
+
+    val pythonProjectPath = Option(pythonProject.get.filePath)
+
+    val projectName = pythonProject.get.projectName
+    val projectType = pythonProject.get.scriptType
+
+    val f = mapParams("fitParam", params)
+
+    val systemParam = mapParams("systemParam", params)
+    val mlflowConfig = MLFlowConfig.buildFromSystemParam(systemParam)
+    val pythonConfig = PythonConfig.buildFromSystemParam(systemParam)
+    val envs = EnvConfig.buildFromSystemParam(systemParam)
+
+
+    val wowRDD = df.toJSON.rdd.mapPartitionsWithIndex { case (algIndex, iter) =>
+
+      ScriptSQLExec.setContext(mlsqlContext)
+
+      val localPathConfig = LocalPathConfig.buildFromParams(path)
+      var tempDataLocalPathWithAlgSuffix = localPathConfig.localDataPath
+
+      if (enableDataLocal) {
+        tempDataLocalPathWithAlgSuffix = tempDataLocalPathWithAlgSuffix + "/" + algIndex
+        val msg = s"dataLocalFormat enabled ,system will generate data in ${tempDataLocalPathWithAlgSuffix} "
+        logInfo(format(msg))
+        HDFSOperator.saveFile(tempDataLocalPathWithAlgSuffix, UUID.randomUUID().toString + ".json", iter.map(("", _)))
+      }
+
+      val paramMap = new util.HashMap[String, Object]()
+      var item = f.asJava
+      if (!f.contains("modelPath")) {
+        item = (f + ("modelPath" -> path)).asJava
+      }
+
+      val resourceParams = new ResourceManager(f).loadResourceInTrain
+
+      val taskDirectory = localPathConfig.localRunPath + "/" + projectName
+      val tempModelLocalPath = s"${localPathConfig.localModelPath}/${algIndex}"
+
+      paramMap.put("fitParam", item)
+
+      if (!kafkaParam.isEmpty) {
+        val kafkaP = kafkaParam + ("group_id" -> (kafkaParam("group_id") + "_" + algIndex))
+        paramMap.put("kafkaParam", kafkaP.asJava)
+      }
+
+      val internalSystemParam = Map(
+        str[RunPythonConfig.InternalSystemParam](_.stopFlagNum) -> stopFlagNum,
+        str[RunPythonConfig.InternalSystemParam](_.tempModelLocalPath) -> tempModelLocalPath,
+        str[RunPythonConfig.InternalSystemParam](_.tempDataLocalPath) -> tempDataLocalPathWithAlgSuffix,
+        str[RunPythonConfig.InternalSystemParam](_.resource) -> resourceParams.asJava
+      )
+
+      paramMap.put(RunPythonConfig.internalSystemParam, internalSystemParam.asJava)
+
+      pythonProjectPath match {
+        case Some(_) =>
+          if (projectType == MLFlow) {
+            logInfo(format(s"'${pythonProjectPath.get}' is MLflow project. download it from [${pythonProject}] to local [${taskDirectory}]"))
+            SQLPythonAlg.downloadPythonProject(taskDirectory, pythonProjectPath)
+          } else {
+            val localPath = taskDirectory + "/" + pythonProjectPath.get.split("/").last
+            logInfo(format(s"'${pythonProjectPath.get}' is Normal project. download it from [${pythonProject}] to local [${localPath}]"))
+            SQLPythonAlg.downloadPythonProject(localPath, pythonProjectPath)
+          }
+
+
+        case None =>
+          // this will not happen, cause even script is a project contains only one python script file.
+          throw new RuntimeException("The project or script you configured in pythonScriptPath is not a validate project")
+      }
+
+
+      val command = new PythonAlgExecCommand(pythonProject.get, None, None, envs).
+        generateCommand(MLProject.train_command)
+
+
+      val execDesc =
+        s"""
+           |
+           |----------------------------------------------------------------
+           |host: ${NetUtils.getHost}
+           |
+           |Command: ${command.mkString(" ")}
+           |TaskDirectory: ${taskDirectory}
+           |DataDirectory: ${tempDataLocalPathWithAlgSuffix}
+           |ModelDirectory: ${tempModelLocalPath}
+           |
+           |Notice:
+           |
+           |If you wanna keep [${taskDirectory}] for debug, please set
+           |keepLocalDirectory=true in train statement.
+           |
+           |e.g:
+           |
+           |train data as PythonParallelExt.`/tmp/abc` where keepLocalDirectory="true";
+           |----------------------------------------------------------------
+         """.stripMargin
+      logInfo(format(execDesc))
+
+      val modelTrainStartTime = System.currentTimeMillis()
+
+      var score = 0.0
+      var trainFailFlag = false
+      val runner = new PythonProjectExecuteRunner(
+        taskDirectory = taskDirectory,
+        keepLocalDirectory = keepLocalDirectory,
+        envVars = envs,
+        logCallback = (msg) => {
+          ScriptSQLExec.setContextIfNotPresent(mlsqlContext)
+          logInfo(format(msg))
+        }
+      )
+      try {
+
+        val res = runner.run(
+          command = command,
+          params = paramMap,
+          schema = MapType(StringType, MapType(StringType, StringType)),
+          scriptContent = pythonProject.get.fileContent,
+          scriptName = pythonProject.get.fileName,
+          validateData = Array()
+        )
+
+        def filterScore(str: String) = {
+          if (str != null && str.startsWith("mlsql_validation_score:")) {
+            str.split(":").last.toDouble
+          } else 0d
+        }
+
+        val scores = res.map { f =>
+          logInfo(format(f))
+          filterScore(f)
+        }.toSeq
+        score = if (scores.size > 0) scores.head else 0d
+      } catch {
+        case e: Exception =>
+          logError(format_cause(e))
+          e.printStackTrace()
+          trainFailFlag = true
+      }
+
+      val modelTrainEndTime = System.currentTimeMillis()
+
+      val modelHDFSPath = SQLPythonFunc.getAlgModelPath(path, keepVersion) + "/" + algIndex
+      try {
+        // If training failed, we do not need
+        // copy model to hdfs
+        if (!trainFailFlag) {
+          //copy model to HDFS
+          val fs = FileSystem.get(new Configuration())
+          if (!keepVersion) {
+            fs.delete(new Path(modelHDFSPath), true)
+          }
+          fs.copyFromLocalFile(new Path(tempModelLocalPath),
+            new Path(modelHDFSPath))
+        }
+      } catch {
+        case e: Exception =>
+          e.printStackTrace()
+          trainFailFlag = true
+      } finally {
+        // delete local model
+        FileUtils.deleteDirectory(new File(tempModelLocalPath))
+        // delete local data
+        if (!keepLocalDirectory) {
+          FileUtils.deleteDirectory(new File(tempDataLocalPathWithAlgSuffix))
+        }
+      }
+      val status = if (trainFailFlag) "fail" else "success"
+      val row = Row.fromSeq(Seq(
+        modelHDFSPath,
+        algIndex,
+        pythonProject.get.fileName,
+        score,
+        status,
+        modelTrainStartTime,
+        modelTrainEndTime,
+        f,
+        execDesc
+      ))
+      Seq(row).toIterator
+    }
+
+    df.sparkSession.createDataFrame(wowRDD, PythonTrainingResultSchema.algSchema).write.mode(SaveMode.Overwrite).parquet(SQLPythonFunc.getAlgMetalPath(path, keepVersion) + "/0")
+
+    val tempRDD = df.sparkSession.sparkContext.parallelize(Seq(Seq(
+      Map(
+        str[PythonConfig](_.pythonPath) -> pythonConfig.pythonPath,
+        str[PythonConfig](_.pythonVer) -> pythonConfig.pythonVer
+      ), params)), 1).map { f =>
+      Row.fromSeq(f)
+    }
+    df.sparkSession.createDataFrame(tempRDD, PythonTrainingResultSchema.trainParamsSchema).
+      write.
+      mode(SaveMode.Overwrite).
+      parquet(SQLPythonFunc.getAlgMetalPath(path, keepVersion) + "/1")
+
+    df.sparkSession.read.parquet(SQLPythonFunc.getAlgMetalPath(path, keepVersion) + "/0")
+  }
+
   def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
 
     val keepVersion = params.getOrElse("keepVersion", "true").toBoolean

--- a/streamingpro-mlsql/src/test/scala/streaming/test/pythonalg/PythonMLSpec2.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/pythonalg/PythonMLSpec2.scala
@@ -23,8 +23,6 @@ import java.nio.charset.Charset
 import java.util.UUID
 
 import com.google.common.io.Files
-import net.csdn.ServiceFramwork
-import net.csdn.bootstrap.Bootstrap
 import net.csdn.common.collections.WowCollections
 import net.csdn.junit.BaseControllerTest
 import net.sf.json.JSONArray
@@ -161,6 +159,23 @@ class PythonMLSpec2 extends BasicSparkOperation with SpecFunctions with BasicMLS
       val status = spark.sql(s"select * from ${table}").collect().map(f => f.getAs[String]("status")).head
       assert(status == "success")
 
+
+    }
+  }
+
+  "SQLPythonParallelExt " should "work fine" in {
+    withBatchContext(setupBatchContext(batchParams, "classpath:///test/empty.json")) { runtime: SparkRuntime =>
+      //执行sql
+      implicit val spark = runtime.sparkSession
+      mockServer
+      val sq = createSSEL(spark, "")
+      //train
+      ScriptSQLExec.parse(ScriptCode._j1, sq)
+
+      var table = sq.getLastSelectTable().get
+      val res = spark.sql(s"select * from output").collect()
+      assert(res.length == 1)
+      assert(res.head.getAs[String](0).contains("jack"))
 
     }
   }

--- a/streamingpro-mlsql/src/test/scala/streaming/test/pythonalg/code/ScriptCode.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/test/pythonalg/code/ScriptCode.scala
@@ -22,6 +22,62 @@ case class ScriptCode(modelPath: String, projectPath: String, featureTablePath: 
 
 object ScriptCode {
 
+  val _j1 =
+    """
+      |set python1='''
+      |import os
+      |import warnings
+      |import sys
+      |
+      |import mlsql
+      |
+      |if __name__ == "__main__":
+      |    warnings.filterwarnings("ignore")
+      |
+      |    tempDataLocalPath = mlsql.internal_system_param["tempDataLocalPath"]
+      |
+      |    isp = mlsql.params()["internalSystemParam"]
+      |    tempModelLocalPath = isp["tempModelLocalPath"]
+      |    if not os.path.exists(tempModelLocalPath):
+      |        os.makedirs(tempModelLocalPath)
+      |    with open(tempModelLocalPath + "/result.txt", "w") as f:
+      |        f.write("jack")
+      |''';
+      |
+      |set dependencies='''
+      |name: tutorial
+      |dependencies:
+      |  - python=3.6
+      |  - pip:
+      |    - numpy==1.14.3
+      |    - kafka-python==1.4.3
+      |    - pyspark==2.3.2
+      |    - pandas==0.22.0
+      |    - scikit-learn==0.19.1
+      |    - scipy==1.1.0
+      |''';
+      |
+      |set modelPath="/tmp/jack2";
+      |
+      |set data='''
+      |{"jack":1}
+      |''';
+      |
+      |load jsonStr.`data` as testData;
+      |load script.`python1` as python1;
+      |load script.`dependencies` as dependencies;
+      |
+      |-- train sklearn model
+      |run testData as PythonParallelExt.`${modelPath}`
+      |where scripts="python1"
+      |and entryPoint="python1"
+      |and condaFile="dependencies"
+      |;
+      |
+      |load text.`${modelPath}/model/0` as output;   -- 查看目标文件
+      |
+      |
+    """.stripMargin
 
   val train =
     """


### PR DESCRIPTION
# What changes were proposed in this pull request?
#869 
- [x] Finshed changes describe

# How was this patch tested?
- [x] Testing done

# Are there and DOC need to update?
- [x] Doc is finished

# Spark Core Compatibility
ALL

Here are example script:

```
set python1='''
import os
import warnings
import sys

import mlsql

if __name__ == "__main__":
    warnings.filterwarnings("ignore")

    tempDataLocalPath = mlsql.internal_system_param["tempDataLocalPath"]

    isp = mlsql.params()["internalSystemParam"]
    tempModelLocalPath = isp["tempModelLocalPath"]
    if not os.path.exists(tempModelLocalPath):
        os.makedirs(tempModelLocalPath)
    with open(tempModelLocalPath + "/result.txt", "w") as f:
        f.write("jack")
''';

set dependencies='''
name: tutorial
dependencies:
  - python=3.6
  - pip:
    - numpy==1.14.3
    - kafka-python==1.4.3
    - pyspark==2.3.2
    - pandas==0.22.0
    - scikit-learn==0.19.1
    - scipy==1.1.0
''';

set modelPath="/tmp/jack2";

set data='''
{"jack":1}
''';

load jsonStr.`data` as testData;
load script.`python1` as python1;
load script.`dependencies` as dependencies;

-- train sklearn model
run testData as PythonParallelExt.`${modelPath}`
where scripts="python1"
and entryPoint="python1"
and condaFile="dependencies"
and keepLocalDirectory="true"
; 

load text.`${modelPath}/model/0` as output;   -- 查看目标文件


```
