### PR TITLE
[DataSource][add] add default behavior for stream datasource.

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/LoadAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/LoadAdaptor.scala
@@ -59,7 +59,7 @@ class LoadAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
     }
 
 
-    if (format.startsWith("kafka") || format.startsWith("mockStream")) {
+    if (format.startsWith("kafka") || format.startsWith("mockStream") || option.contains("stream.source")) {
       scriptSQLExecListener.addEnv("stream", "true")
       new StreamLoadAdaptor(scriptSQLExecListener, option, path, tableName, format).parse
     } else {
@@ -185,6 +185,8 @@ class StreamLoadAdaptor(scriptSQLExecListener: ScriptSQLExecListener,
         val format = "org.apache.spark.sql.execution.streaming.mock.MockStreamSourceProvider"
         table = reader.format(format).options(option + ("path" -> cleanStr(path))).load()
       case _ =>
+        val provider = option.getOrElse("provider", format)
+        table = reader.format(provider).options(option).load()
     }
     table = withWaterMark(table, option)
 


### PR DESCRIPTION

# What changes were proposed in this pull request?
- [x] add default behavior for stream datasource.


people can easy add a new stream datasource by implement `org.apache.spark.sql.execution.streaming.Source`,
 and than add option `stramn.source` in mlsql script.

here is an example:
```sql
set streamName = "test";
load fchen.`` options stream.source = "true"
and provider = "xxx.xxx.SourceProvider"
as table1;
```

# How was this patch tested?
- [x] N/A

# Are there and DOC need to update?
- [x] N/A
# Spark Core Compatibility

- [x] All