### PR TITLE
[ScriptUDF][add] add JavaRuntimeCompileUDF support

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/udf/JavaRuntimeCompileUDF.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/udf/JavaRuntimeCompileUDF.scala
@@ -1,0 +1,93 @@
+package streaming.udf
+
+import java.util.UUID
+
+import org.apache.spark.sql.MLSQLUtils
+import org.apache.spark.sql.types.DataType
+import streaming.common.{Md5, SourceCodeCompiler}
+import streaming.dsl.mmlib.algs.ScriptUDFCacheKey
+import streaming.log.Logging
+
+/**
+ * Created by fchen on 2018/11/15.
+ */
+object JavaRuntimeCompileUDF extends RuntimeCompileUDF with Logging {
+  /**
+   * udf reture DataType
+   * due to java type erasure, it's not good idea get function return type by `method.getReturnType`,
+   * a batter idea is find return type form source code.
+   */
+  override def returnType(scriptCacheKey: ScriptUDFCacheKey): Option[DataType] = {
+    val clazz = driverExecute(scriptCacheKey).asInstanceOf[Class[_]]
+    val method = SourceCodeCompiler.getMethod(clazz, scriptCacheKey.methodName)
+    Option(MLSQLUtils.getJavaDataType(method.getGenericReturnType)._1)
+  }
+
+  /**
+   * reture udf input argument number
+   */
+  override def argumentNum(scriptCacheKey: ScriptUDFCacheKey): Int = {
+    val clazz = driverExecute(scriptCacheKey).asInstanceOf[Class[_]]
+    val method = SourceCodeCompiler.getMethod(clazz, scriptCacheKey.methodName)
+    method.getParameterCount
+  }
+
+  /**
+   * wrap original source code.
+   * e.g. in [[ScalaRuntimCompileUDAF]], user pass function code, we should wrap code as a class.
+   * so the runtime compiler will compile source code as runtime instance.
+   */
+  override def wrapCode(scriptCacheKey: ScriptUDFCacheKey): ScriptUDFCacheKey = {
+
+//    val className = s"StreamingProJavaUDF_${UUID.randomUUID().toString.replaceAll("-", "")}"
+    val className = if (scriptCacheKey.className == null || scriptCacheKey.className.isEmpty) {
+      "UDF"
+    } else {
+      scriptCacheKey.className
+    }
+    val codeMd5 = Md5.md5Hash(scriptCacheKey.originalCode)
+    val packageName = s"streaming.udf.java.sun${codeMd5}"
+    val newfun =
+      s"""
+         |package ${packageName};
+         |
+         |${scriptCacheKey.originalCode}
+         |
+            """.stripMargin
+    val fullClassName = packageName + "." + className
+
+    scriptCacheKey.copy(wrappedCode = newfun, className = fullClassName)
+  }
+
+  override def invokeFunctionFromInstance(scriptCacheKey: ScriptUDFCacheKey)
+  : (Seq[Object]) => AnyRef = {
+    lazy val clz = driverExecute(scriptCacheKey).asInstanceOf[Class[_]]
+    lazy val instance = SourceCodeCompiler.newInstance(clz)
+    lazy val method = SourceCodeCompiler.getMethod(clz, scriptCacheKey.methodName)
+
+    val func: (Seq[Object]) => AnyRef = {
+      (args: Seq[Object]) => method.invoke(instance, args: _*)
+    }
+    func
+  }
+
+  /**
+   * validate the source code
+   */
+  override def check(sourceCode: String): Boolean = {
+    true
+  }
+
+  /**
+   * how to compile the language source code with jvm.
+   *
+   * @param scriptCacheKey
+   * @return
+   */
+  override def compile(scriptCacheKey: ScriptUDFCacheKey): AnyRef = {
+    logInfo("compile java source code: \n" + scriptCacheKey.wrappedCode)
+    SourceCodeCompiler.compileJava(scriptCacheKey.wrappedCode, scriptCacheKey.className)
+  }
+
+  override def lang: String = "java"
+}

--- a/streamingpro-mlsql/src/main/java/streaming/udf/RuntimeCompileScriptInterface.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/udf/RuntimeCompileScriptInterface.scala
@@ -21,7 +21,6 @@ package streaming.udf
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 import streaming.dsl.mmlib.algs.ScriptUDFCacheKey
 import streaming.log.Logging
-
 import scala.collection.mutable.HashMap
 
 /**
@@ -72,6 +71,7 @@ object RuntimeCompileScriptFactory extends Logging {
 
   registerUDF(PythonRuntimeCompileUDF.lang, PythonRuntimeCompileUDF)
   registerUDF(ScalaRuntimeCompileUDF.lang, ScalaRuntimeCompileUDF)
+  registerUDF(JavaRuntimeCompileUDF.lang, JavaRuntimeCompileUDF)
   registerUDAF(ScalaRuntimeCompileUDAF.lang, ScalaRuntimeCompileUDAF)
   registerUDAF(PythonRuntimeCompileUDAF.lang, PythonRuntimeCompileUDAF)
 

--- a/streamingpro-mlsql/src/test/scala/streaming/dsl/mmlib/algs/ScriptUDFSuite.scala
+++ b/streamingpro-mlsql/src/test/scala/streaming/dsl/mmlib/algs/ScriptUDFSuite.scala
@@ -30,6 +30,185 @@ import streaming.dsl.ScriptSQLExec
  */
 class ScriptUDFSuite extends BasicSparkOperation with SpecFunctions with BasicMLSQLConfig {
 
+  "test java script map return type" should "work fine" in {
+    withBatchContext(setupBatchContext(batchParamsWithoutHive)) { runtime: SparkRuntime =>
+      implicit val spark = runtime.sparkSession
+      var sq = createSSEL
+      ScriptSQLExec.parse(
+        """
+          |  set echoFun='''
+          |  import java.util.HashMap;
+          |  import java.util.Map;
+          |  public class UDF {
+          |      public Map<String, String> apply(String s) {
+          |        Map m = new HashMap<>();
+          |        m.put(s, s);
+          |        return m;
+          |    }
+          |  }
+          |  ''';
+          |
+          |  load script.`echoFun` as scriptTable;
+          |
+          |  register ScriptUDF.`scriptTable` as funx
+          |  options lang="java"
+          |  ;
+          |
+          |  -- create a data table.
+          |  set data='''
+          |  {"a":"a"}
+          |  ''';
+          |  load jsonStr.`data` as dataTable;
+          |
+          |  select funx(a) as res from dataTable as output;
+          |
+        """.stripMargin, sq)
+
+      val result = runtime.sparkSession.sql("select * from output").collect()
+      assert(result.size == 1)
+      assert(result.head.getAs[Map[String, String]]("res").get("a").head == "a")
+    }
+  }
+
+  "test java script Map[string, Array[Int]] return type" should "work fine" in {
+    withBatchContext(setupBatchContext(batchParamsWithoutHive)) { runtime: SparkRuntime =>
+      implicit val spark = runtime.sparkSession
+      var sq = createSSEL
+      ScriptSQLExec.parse(
+        """
+          |  set echoFun='''
+          |  import java.util.HashMap;
+          |  import java.util.Map;
+          |  public class UDF {
+          |    public Map<String, Integer[]> apply(String s) {
+          |      Map<String, Integer[]> m = new HashMap<>();
+          |      Integer[] arr = {1};
+          |      m.put(s, arr);
+          |      return m;
+          |    }
+          |  }
+          |  ''';
+          |
+          |  load script.`echoFun` as scriptTable;
+          |
+          |  register ScriptUDF.`scriptTable` as funx
+          |  options lang="java"
+          |  ;
+          |
+          |  -- create a data table.
+          |  set data='''
+          |  {"a":"a"}
+          |  ''';
+          |  load jsonStr.`data` as dataTable;
+          |
+          |  select funx(a) as res from dataTable as output;
+          |
+        """.stripMargin, sq)
+
+      val result = runtime.sparkSession.sql("select * from output").collect()
+      assert(result.size == 1)
+      result.foreach(println)
+      assert(result.head.getAs[Map[String, WrappedArray[Int]]]("res")("a")(0) == 1)
+    }
+  }
+
+  "test java script with a class name which is different from 'UDF'" should "work fine" in {
+    withBatchContext(setupBatchContext(batchParamsWithoutHive)) { runtime: SparkRuntime =>
+      implicit val spark = runtime.sparkSession
+      var sq = createSSEL
+      ScriptSQLExec.parse(
+        """
+          |  set echoFun='''
+          |  import java.util.HashMap;
+          |  import java.util.Map;
+          |  public class Test {
+          |      public Map<String, String> apply(String s) {
+          |        Map m = new HashMap<>();
+          |        m.put(s, s);
+          |        return m;
+          |    }
+          |  }
+          |  ''';
+          |
+          |  load script.`echoFun` as scriptTable;
+          |
+          |  register ScriptUDF.`scriptTable` as funx
+          |  options lang="java"
+          |  and className = "Test"
+          |  ;
+          |
+          |  -- create a data table.
+          |  set data='''
+          |  {"a":"a"}
+          |  ''';
+          |  load jsonStr.`data` as dataTable;
+          |
+          |  select funx(a) as res from dataTable as output;
+          |
+        """.stripMargin, sq)
+
+      val result = runtime.sparkSession.sql("select * from output").collect()
+      assert(result.size == 1)
+      assert(result.head.getAs[Map[String, String]]("res").get("a").head == "a")
+    }
+  }
+
+
+  "test multi java script with the same class name" should "work fine" in {
+    withBatchContext(setupBatchContext(batchParamsWithoutHive)) { runtime: SparkRuntime =>
+      implicit val spark = runtime.sparkSession
+      var sq = createSSEL
+      ScriptSQLExec.parse(
+        """
+          |  set echoFun='''
+          |  import java.util.HashMap;
+          |  import java.util.Map;
+          |  public class UDF {
+          |      public Map<String, String> apply(String s) {
+          |        Map m = new HashMap<>();
+          |        m.put(s, s);
+          |        return m;
+          |    }
+          |  }
+          |  ''';
+          |
+          |  set fun2='''
+          |  public class UDF {
+          |    public int apply(String s) {
+          |      return 1;
+          |    }
+          |  }
+          |  ''';
+          |
+          |  load script.`echoFun` as scriptTable;
+          |
+          |  register ScriptUDF.`scriptTable` as fun1
+          |  options lang="java"
+          |  ;
+          |
+          |  load script.`fun2` as scriptTable;
+          |
+          |  register ScriptUDF.`scriptTable` as fun2
+          |  options lang="java"
+          |  ;
+          |
+          |  -- create a data table.
+          |  set data='''
+          |  {"a":"a"}
+          |  ''';
+          |  load jsonStr.`data` as dataTable;
+          |
+          |  select fun1(a) as res1, fun2(a) as res2 from dataTable as output;
+          |
+        """.stripMargin, sq)
+
+      val result = runtime.sparkSession.sql("select * from output").collect()
+      assert(result.size == 1)
+      assert(result.head.getAs[Map[String, String]]("res1").get("a").head == "a")
+      assert(result.head.getAs[Int]("res2") == 1)
+    }
+  }
+
   "test scala script map return type" should "work fine" in {
     withBatchContext(setupBatchContext(batchParamsWithoutHive)) { runtime: SparkRuntime =>
       implicit val spark = runtime.sparkSession

--- a/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/sql/MLSQLUtils.scala
+++ b/streamingpro-spark-2.2.0-adaptor/src/main/java/org/apache/spark/sql/MLSQLUtils.scala
@@ -1,0 +1,18 @@
+package org.apache.spark.sql
+
+import java.lang.reflect.Type
+
+import org.apache.spark.sql.catalyst.JavaTypeInference
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.util.Utils
+
+object MLSQLUtils {
+  def getJavaDataType(tpe: Type): (DataType, Boolean) = {
+    JavaTypeInference.inferDataType(tpe)
+  }
+
+  def getContextOrSparkClassLoader(): ClassLoader = {
+    Utils.getContextOrSparkClassLoader
+  }
+
+}

--- a/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/sql/MLSQLUtils.scala
+++ b/streamingpro-spark-2.3.0-adaptor/src/main/java/org/apache/spark/sql/MLSQLUtils.scala
@@ -1,0 +1,18 @@
+package org.apache.spark.sql
+
+import java.lang.reflect.Type
+
+import org.apache.spark.sql.catalyst.JavaTypeInference
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.util.Utils
+
+object MLSQLUtils {
+  def getJavaDataType(tpe: Type): (DataType, Boolean) = {
+    JavaTypeInference.inferDataType(tpe)
+  }
+
+  def getContextOrSparkClassLoader(): ClassLoader = {
+    Utils.getContextOrSparkClassLoader
+  }
+
+}

--- a/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/sql/MLSQLUtils.scala
+++ b/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/sql/MLSQLUtils.scala
@@ -1,0 +1,18 @@
+package org.apache.spark.sql
+
+import java.lang.reflect.Type
+
+import org.apache.spark.sql.catalyst.JavaTypeInference
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.util.Utils
+
+object MLSQLUtils {
+  def getJavaDataType(tpe: Type): (DataType, Boolean) = {
+    JavaTypeInference.inferDataType(tpe)
+  }
+
+  def getContextOrSparkClassLoader(): ClassLoader = {
+    Utils.getContextOrSparkClassLoader
+  }
+
+}


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [x] java runtime compile udf support

here is an example:
```sql
set echoFun='''
import java.util.HashMap;
import java.util.Map;
public class UDF {
  public Map<String, Integer[]> apply(String s) {
    Map<String, Integer[]> m = new HashMap<>();
    Integer[] arr = {1};
    m.put(s, arr);
    return m;
  }
}
''';

load script.`echoFun` as scriptTable;

register ScriptUDF.`scriptTable` as funx
options lang="java"
;

-- create a data table.
set data='''
{"a":"a"}
''';
load jsonStr.`data` as dataTable;

select funx(a) as res from dataTable as output;

```

# How was this patch tested?
- [x] Testing done
```shell
mvn -Pcrawler -Phive-thrift-server -Pdsl -Pstreamingpro-spark-2.3.0-adaptor -Pspark-2.3.0 -am -pl streamingpro-mlsql clean test -Dsuites="*ScriptUDFSuite"
```

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
- [x] ALL
