### PR TITLE
[Set][add] Support `spark.scheduler.pool` for mlsql script.

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/SetAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/SetAdaptor.scala
@@ -70,7 +70,15 @@ class SetAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapto
       case Some("shell") =>
         value = ShellCommand.execSimpleCommand(evaluate(command)).trim
       case Some("conf") =>
-        scriptSQLExecListener.sparkSession.sql(s""" set ${key} = ${original_command} """)
+        key match {
+          case "spark.scheduler.pool" =>
+            scriptSQLExecListener.sparkSession
+              .sqlContext
+              .sparkContext
+              .setLocalProperty(key, original_command)
+          case _ =>
+            scriptSQLExecListener.sparkSession.sql(s""" set ${key} = ${original_command} """)
+        }
       case Some("defaultParam") =>
         overwrite = false
       case _ =>


### PR DESCRIPTION
To enable `spark.scheduler.pool` configuration support in mlsql script.

1. add follow configurations in your service start script. for more detail about **spark job scheduling**, please visit [Spark job-scheduling](http://spark.apache.org/docs/latest/job-scheduling.html)
```
      "-spark.scheduler.mode", "FAIR",
      "-spark.scheduler.allocation.file", "/path/to/fairscheduler.xml"
```
2. set `Set` command in your mlsql script.
here is an example:
```sql
set spark.scheduler.pool = test options type = "conf";
select 1 as a,'jack' as b as bbc;
```
then, your script will run in **test** pool.

# What changes were proposed in this pull request?
- [x] Finshed changes describe

# How was this patch tested?
- [x] None
# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
- [x] All
