### PR TITLE
[REST API][add] add result api result control mechanism.

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/core/LoalSparkServiceApp.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/LoalSparkServiceApp.scala
@@ -29,6 +29,8 @@ object LocalSparkServiceApp {
       "-streaming.rest", "true",
       "-streaming.thrift", "false",
       "-streaming.platform", "spark",
+      "-spark.mlsql.enable.max.result.limit", "true",
+      "-spark.mlsql.restful.api.max.result.size", "7",
       //"-streaming.job.file.path", "classpath:///test/empty.json",
       "-streaming.spark.service", "true",
       "-streaming.job.cancel", "true",

--- a/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/MLSQLConf.scala
+++ b/streamingpro-spark-2.4.0-adaptor/src/main/java/org/apache/spark/MLSQLConf.scala
@@ -186,6 +186,21 @@ object MLSQLConf {
       .timeConf(TimeUnit.SECONDS)
       .createWithDefault(TimeUnit.SECONDS.toSeconds(60L))
 
+  val ENABLE_MAX_RESULT_SIZE: ConfigEntry[Boolean] =
+    MLSQLConfigBuilder("spark.mlsql.enable.max.result.limit")
+      .doc("enable restful max result size limitation. when you enable this configuration." +
+        " you should pass `maxResultSize` for your rest request." +
+        " if not, you take only max 1000 record.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val RESTFUL_API_MAX_RESULT_SIZE: ConfigEntry[Long] =
+    MLSQLConfigBuilder("spark.mlsql.restful.api.max.result.size")
+      .doc("the max size of restful api result.")
+      .longConf
+      .createWithDefault(1000)
+
+
   def getAllDefaults: Map[String, String] = {
     entries.entrySet().asScala.map { kv =>
       (kv.getKey, kv.getValue.defaultValueString)


### PR DESCRIPTION
# What changes were proposed in this pull request?
now we can enable restful api result size limitation with set configuration `spark.mlsql.enable.max.result.limit = true` and global limitation size `spark.mlsql.restful.api.max.result.size = ${intValue}`, or you can just add `maxResultSize` in your rest request parameters. Notes that global limitation has high priority than rest request parameter.

# How was this patch tested?
- [ ] N/A

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
- [x] ALL