### PR TITLE
jython udf support null

### DIFF
--- a/streamingpro-jython/src/main/java/streaming/jython/JythonUtils.java
+++ b/streamingpro-jython/src/main/java/streaming/jython/JythonUtils.java
@@ -19,11 +19,10 @@
 package streaming.jython;
 
 import org.python.core.*;
+import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 import java.util.*;
-
-import scala.collection.JavaConverters;
 
 /**
  * Created by allwefantasy on 28/8/2018.
@@ -124,6 +123,8 @@ public class JythonUtils {
             return new PyFloat((double) o);
         } else if (o instanceof Boolean) {
             return new PyBoolean((boolean) o);
+        } else if (o == null) {
+            return Py.None;
         } else if (o instanceof Character) {
             return Py.newStringOrUnicode(((Character) o).toString());
         } else if (o instanceof String) {

--- a/streamingpro-mlsql/src/test/scala/tech/mlsql/test/client/ClientModeSpec.scala
+++ b/streamingpro-mlsql/src/test/scala/tech/mlsql/test/client/ClientModeSpec.scala
@@ -1,4 +1,4 @@
-package tech.mlsql.test
+package tech.mlsql.test.client
 
 import java.nio.charset.Charset
 import java.util.UUID


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [ ] Finshed changes describe

# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility

```sql
set convert_data='''

def apply(self,m):
    return "data:" + str(m)
''';

load script.`convert_data` as scriptTable;

register ScriptUDF.`scriptTable` as convert_data
options lang="python" and dataType="string";

select convert_data(null) as a ,"c" as c as b;
```