### PR TITLE
[mod] parseRef method add params

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/core/datasource/MLSQLBaseStreamSource.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/datasource/MLSQLBaseStreamSource.scala
@@ -15,7 +15,6 @@ abstract class MLSQLBaseStreamSource extends MLSQLSource with MLSQLSink with MLS
     config
   }
 
-
   override def save(batchWriter: DataFrameWriter[Row], config: DataSinkConfig): Any = {
     val oldDF = config.df.get
     var option = config.config
@@ -26,7 +25,7 @@ abstract class MLSQLBaseStreamSource extends MLSQLSource with MLSQLSink with MLS
     val writer: DataStreamWriter[Row] = oldDF.writeStream
     var path = resolvePath(config.path)
 
-    val Array(db, table) = parseRef(aliasFormat, path, (options: Map[String, String]) => {
+    val Array(db, table) = parseRef(aliasFormat, path, dbSplitter, (options: Map[String, String]) => {
       writer.options(options)
     })
 

--- a/streamingpro-mlsql/src/main/java/streaming/core/datasource/impl/MLSQLCarbondata.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/datasource/impl/MLSQLCarbondata.scala
@@ -18,7 +18,7 @@ class MLSQLCarbondata(override val uid: String) extends MLSQLBaseFileSource with
 
 
   override def save(writer: DataFrameWriter[Row], config: DataSinkConfig): Unit = {
-    val Array(db, table) = parseRef(shortFormat, config.path, (options: Map[String, String]) => {
+    val Array(db, table) = parseRef(shortFormat, config.path, dbSplitter, (options: Map[String, String]) => {
       writer.options(options)
     })
 
@@ -33,7 +33,7 @@ class MLSQLCarbondata(override val uid: String) extends MLSQLBaseFileSource with
   }
 
   override def sourceInfo(config: DataAuthConfig): SourceInfo = {
-    val Array(db, table) = parseRef(shortFormat, config.path, (options: Map[String, String]) => {
+    val Array(db, table) = parseRef(shortFormat, config.path, dbSplitter, (options: Map[String, String]) => {
     })
     SourceInfo(shortFormat, db, table)
   }

--- a/streamingpro-mlsql/src/main/java/streaming/core/datasource/impl/MLSQLRedis.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/datasource/impl/MLSQLRedis.scala
@@ -21,7 +21,7 @@ class MLSQLRedis(override val uid: String) extends MLSQLBaseFileSource with WowP
 
   override def save(writer: DataFrameWriter[Row], config: DataSinkConfig): Unit = {
 
-    val Array(db, table) = parseRef(shortFormat, config.path, (options: Map[String, String]) => {
+    val Array(db, table) = parseRef(shortFormat, config.path, dbSplitter, (options: Map[String, String]) => {
       writer.options(options)
     })
     val format = config.config.getOrElse("implClass", fullFormat)
@@ -30,7 +30,7 @@ class MLSQLRedis(override val uid: String) extends MLSQLBaseFileSource with WowP
   }
 
   override def sourceInfo(config: DataAuthConfig): SourceInfo = {
-    val Array(db, table) = parseRef(shortFormat, config.path, (options: Map[String, String]) => {
+    val Array(db, table) = parseRef(shortFormat, config.path, dbSplitter, (options: Map[String, String]) => {
     })
     SourceInfo(shortFormat, db, table)
   }

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/DslAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/DslAdaptor.scala
@@ -107,17 +107,19 @@ trait DslTool {
     withPathPrefix(scriptSQLExecListener.pathPrefix(resourceOwner), cleanStr(path))
   }
 
-  def parseRef(format: String, path: String, callback: Map[String, String] => Unit) = {
-    var final_path = path
-    var db = ""
-    if (final_path.contains(".")) {
-      val Array(_dbname, _dbtable) = final_path.split("\\.", 2)
-      db = _dbname
-      ConnectMeta.presentThenCall(DBMappingKey(format, _dbname), options => {
-        final_path = _dbtable
-        callback(options)
-      })
+  def parseRef(format: String, path: String, separator: String, callback: Map[String, String] => Unit) = {
+    var finalPath = path
+    var dbName = ""
+
+    val firstIndex = finalPath.indexOf(separator)
+
+    if (firstIndex > 0) {
+
+      dbName = finalPath.substring(0, firstIndex)
+      finalPath = finalPath.substring(firstIndex + 1)
+      ConnectMeta.presentThenCall(DBMappingKey(format, dbName), options => callback(options))
     }
-    Array(db, final_path)
+
+    Array(dbName, finalPath)
   }
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [ ] complete datasource, parse ref can use custom separator (e.g MLSQLDataSource.dbSplitter)

# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
