### PR TITLE
hdfs ls command extend function of json format

### DIFF
--- a/streamingpro-mlsql/src/main/java/tech/mlsql/ets/HDFSCommand.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/ets/HDFSCommand.scala
@@ -36,9 +36,13 @@ class HDFSCommand(override val uid: String) extends SQLAlg with Functions with W
     finally {
       fsShell.close()
     }
-
     import spark.implicits._
-    spark.createDataset[String](Seq(output)).toDF("fileSystem")
+    if (args.contains("-F")) {
+      val ds = spark.createDataset(output.split("\n").toSeq)
+      spark.read.json(ds)
+    } else {
+      spark.createDataset[String](Seq(output)).toDF("fileSystem")
+    }
   }
 
 

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/ets/hdfs/WowFsShell.java
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/ets/hdfs/WowFsShell.java
@@ -19,6 +19,7 @@
 package tech.mlsql.ets.hdfs;
 
 import org.apache.commons.lang.WordUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -95,7 +96,12 @@ public class WowFsShell extends Configured implements Tool {
      */
     public WowFsShell(Configuration conf, String basePath) {
         super(conf);
-        this.basePath = basePath;
+        if(!StringUtils.isBlank(basePath)) {
+            this.basePath = basePath;
+        } else {
+            this.basePath = "/";
+        }
+
     }
 
     protected FileSystem getFS() throws IOException {


### PR DESCRIPTION
We can format the original piece of file information into multiple rows and multiple fields.Input param is "-F".
for example:
!hdfs  -ls -F /Users/zml/pv;
output:
group  length   modification_time    name  owner        path                  permission  replication
staff        5       2019-03-20 15:23  .mesh    zml  /Users/zml/pv/.mesh  -rw-r--r--       1




