### PR TITLE
remove evluate (TrainAdaptor will evluate) .add set type=sql default …

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/dsl/SetAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/SetAdaptor.scala
@@ -76,6 +76,8 @@ class SetAdaptor(scriptSQLExecListener: ScriptSQLExecListener, stage: Stage.stag
     var overwrite = true
     option.get("type") match {
       case Some("sql") =>
+        //Stage.preProcess and SetMode.compile is false ,keep param original sample.
+        value = "${" + key + "}"
         // If we set mode compile, and then we should avoid the sql executed in
         // both preProcess and physical stage.
         val mode = SetMode.withName(option.get(SetMode.keyName).getOrElse(SetMode.runtime.toString))

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/dsl/adaptor/CommandAdaptor.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/dsl/adaptor/CommandAdaptor.scala
@@ -31,7 +31,7 @@ class CommandAdaptor(preProcessListener: PreProcessListener) extends DslAdaptor 
       ctx.getChild(tokenIndex) match {
         case s: CommandValueContext =>
           val oringinalText = s.getText
-          parameters += cleanBlockStr(cleanStr(evaluate(oringinalText)))
+          parameters += cleanBlockStr(cleanStr(oringinalText))
         case s: RawCommandValueContext =>
           val box = ArrayBuffer[String]()
           var prePos = 0


### PR DESCRIPTION
…value

# What changes were proposed in this pull request?
- [x] Finshed changes describe

# How was this patch tested?
- [x] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
2.3 2.4