### PR TITLE
when use mysql binlog require at least 2 cores/ upgrade spark binlog to 0.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <mlsql-ps-service-version>1.3.5</mlsql-ps-service-version>
         <pyjava-version>0.2.0</pyjava-version>
         <delta-plus-version>0.1.1</delta-plus-version>
-        <spark-binlog-version>0.1.6</spark-binlog-version>
+        <spark-binlog-version>0.1.7</spark-binlog-version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [ ] Finshed changes describe

# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
