### PR TITLE
params()是java的map,JSONTool.toJsonStr转换失败

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
@@ -265,7 +265,7 @@ class RestController extends ApplicationController with WowLog {
     val ownerOption = if (params.containsKey("owner")) Some(param("owner")) else None
     val userDefineParams = params.toMap.filter(f => f._1.startsWith("context.")).map(f => (f._1.substring("context.".length), f._2))
     ScriptSQLExec.setContext(new MLSQLExecuteContext(context, param("owner"), context.pathPrefix(None), groupId,
-      userDefineParams ++ Map("__PARAMS__" -> JSONTool.toJsonStr(params()))
+      userDefineParams ++ Map("__PARAMS__" -> JSONTool.toJsonStr(params().toMap))
     ))
     context.addEnv("SKIP_AUTH", param("skipAuth", "true"))
     context.addEnv("HOME", context.pathPrefix(None))


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [ ] Finshed changes describe
场景：需要获取用户请求接口的所有参数，发现ScriptSQLExec.context()可以满足需求。
          但实际获取发现获取的字段userDefinedParam一直为“{}”，经过debug跟踪，发现JSONTool.toJsonStr(params())转换失败导致
原因：params()拿到的是java的map，需要将其转换为scala的map 然后才能进行转换
修改为：
 ScriptSQLExec.setContext(new MLSQLExecuteContext(context, param("owner"), context.pathPrefix(None), groupId,
      userDefineParams ++ Map("__PARAMS__" -> JSONTool.toJsonStr(params().toMap))
    ))

# How was this patch tested?
- [ ] Testing done
- [ ] 已测试完成

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
