### PR TITLE
Enhancement: Retrying mechanism of the callback in /run/script endpoint.

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
@@ -26,10 +26,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import net.csdn.annotation.rest.{At, _}
 import net.csdn.common.collections.WowCollections
-import net.csdn.common.path.Url
 import net.csdn.modules.http.ApplicationController
 import net.csdn.modules.http.RestRequest.Method._
 import net.csdn.modules.transport.HttpTransportService
+import org.apache.commons.httpclient.HttpStatus
+import org.apache.http.HttpResponse
+import org.apache.http.client.fluent.Request
 import org.apache.spark.ps.cluster.Message
 import org.apache.spark.ps.cluster.Message.Pong
 import org.apache.spark.sql._
@@ -87,6 +89,7 @@ class RestController extends ApplicationController with WowLog {
     new Parameter(name = "sessionPerRequest", required = false, description = "by default false", `type` = "boolean", allowEmptyValue = false),
     new Parameter(name = "async", required = false, description = "If set true ,please also provide a callback url use `callback` parameter and the job will run in background and the API will return.  default: false", `type` = "boolean", allowEmptyValue = false),
     new Parameter(name = "callback", required = false, description = "Used when async is set true. callback is a url. default: false", `type` = "string", allowEmptyValue = false),
+    new Parameter(name = "maxRetries", required = false, description = "Max retries of request callback.", `type` = "int", allowEmptyValue = false),
     new Parameter(name = "skipInclude", required = false, description = "disable include statement. default: false", `type` = "boolean", allowEmptyValue = false),
     new Parameter(name = "skipAuth", required = false, description = "disable table authorize . default: true", `type` = "boolean", allowEmptyValue = false),
     new Parameter(name = "skipGrammarValidate", required = false, description = "validate mlsql grammar. default: true", `type` = "boolean", allowEmptyValue = false),
@@ -124,6 +127,8 @@ class RestController extends ApplicationController with WowLog {
       def query = {
         if (paramAsBoolean("async", false)) {
           JobManager.asyncRun(sparkSession, jobInfo, () => {
+            val urlString = param("callback")
+
             try {
               ScriptSQLExec.parse(param("sql"), context,
                 skipInclude = paramAsBoolean("skipInclude", false),
@@ -132,10 +137,18 @@ class RestController extends ApplicationController with WowLog {
                 skipGrammarValidate = paramAsBoolean("skipGrammarValidate", true))
 
               outputResult = getScriptResult(context, sparkSession)
-              htp.post(new Url(param("callback")),
-                Map("stat" -> s"""succeeded""",
-                  "res" -> outputResult,
-                  "jobInfo" -> JSONTool.toJsonStr(jobInfo)))
+
+              val maxTries = Math.max(0, paramAsInt("maxRetries", -1)) + 1
+              val response = RestUtils.executeWithRetrying[HttpResponse](maxTries)(
+                RestUtils.httpClientPost(urlString,
+                  Map("stat" -> s"""succeeded""",
+                    "res" -> outputResult,
+                    "jobInfo" -> JSONTool.toJsonStr(jobInfo))),
+                HttpStatus.SC_OK == _.getStatusLine.getStatusCode,
+                response => logger.error(s"Succeeded SQL callback request failed after ${maxTries} attempts, " +
+                  s"the last response status is: ${response.getStatusLine.getStatusCode}.")
+              )
+              RestUtils.convertResponse(response, urlString)
             } catch {
               case e: Exception =>
                 e.printStackTrace()
@@ -143,11 +156,11 @@ class RestController extends ApplicationController with WowLog {
                 if (paramAsBoolean("show_stack", false)) {
                   format_full_exception(msgBuffer, e)
                 }
-                htp.post(new Url(param("callback")),
+                val response = RestUtils.httpClientPost(urlString,
                   Map("stat" -> s"""failed""",
-                    "msg" -> (e.getMessage + "\n" + msgBuffer.mkString("\n")),
-                    "jobInfo" -> JSONTool.toJsonStr(jobInfo)
-                  ))
+                    "res" -> (e.getMessage + "\n" + msgBuffer.mkString("\n")),
+                    "jobInfo" -> JSONTool.toJsonStr(jobInfo)))
+                RestUtils.convertResponse(response, urlString)
             }
           })
         } else {

--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestUtils.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestUtils.scala
@@ -1,0 +1,47 @@
+package streaming.rest
+
+import net.csdn.common.path.Url
+import net.csdn.modules.transport.{DefaultHttpTransportService, HttpTransportService}
+import net.csdn.modules.transport.HttpTransportService.SResponse
+import org.apache.http.HttpResponse
+import org.apache.http.client.entity.UrlEncodedFormEntity
+import org.apache.http.client.fluent.Request
+import org.apache.http.message.BasicNameValuePair
+import org.apache.http.util.EntityUtils
+
+import scala.collection.JavaConverters._
+
+object RestUtils {
+  def httpClientPost(urlString: String, data: Map[String, String]): HttpResponse = {
+     val nameValuePairs = data
+       .map{ case (name, value) => new BasicNameValuePair(name, value) }.toSeq
+
+    Request.Post(urlString)
+      .addHeader("Content-Type", "application/x-www-form-urlencoded")
+      .body(new UrlEncodedFormEntity(nameValuePairs.asJava, DefaultHttpTransportService.charset))
+      .execute()
+      .returnResponse()
+  }
+
+  def executeWithRetrying[T](maxTries: Int)(function: => T, checker: T => Boolean, failed: T => Unit): T = {
+    Stream.range(0, maxTries)
+      .map(i => (i, function))
+      // Keep trying until the first success or the retries limit has been reached.
+      .find { case (i, result) => checker(result) || {
+        if (i == maxTries - 1) {
+          failed(result)
+          true
+        } else {
+          false
+        }}
+      }
+      .map(_._2)
+      .get
+  }
+
+  def convertResponse(httpResponse: HttpResponse, urlString: String): SResponse =
+    new HttpTransportService.SResponse(
+      httpResponse.getStatusLine.getStatusCode,
+      EntityUtils.toString(httpResponse.getEntity, DefaultHttpTransportService.charset),
+      new Url(urlString))
+}


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [ - ] Add retrying mechanism to the callback calling in /run/script endpoint.

# How was this patch tested?
- [ - ] Currently no UT.
- [ - ] Manual testing:

1. In the mlsql-api-console project, set the response status of /api_v1/job/callback to 500:
<img width="1099" alt="Screen Shot 2021-06-01 at 19 27 26" src="https://user-images.githubusercontent.com/30195472/120315889-674da680-c30f-11eb-8c85-ce98c3168f20.png">

2. Add a maxRetries parameter to the /run/script request:
<img width="1148" alt="Screen Shot 2021-06-02 at 10 38 54" src="https://user-images.githubusercontent.com/30195472/120415839-c69ecb80-c38e-11eb-8d1c-6c453c8a5a38.png">

3. Try execute a SQL query and see the error log:
<img width="1320" alt="Screen Shot 2021-06-02 at 11 38 27" src="https://user-images.githubusercontent.com/30195472/120420515-0ec1ec00-c397-11eb-82aa-934ef665ea56.png">

# Are there and DOC need to update?
- [ ] Doc not finished

# Spark Core Compatibility
