### PR TITLE
Make streamingpro-it module  support Spark 3.1.1

### DIFF
--- a/dev/python/convert_pom.py
+++ b/dev/python/convert_pom.py
@@ -1,38 +1,179 @@
-newlines = []
+import re
+import sys
+from typing import Any, NoReturn, Callable, Dict, List
+import os
 
-meet = False
-meet1 = False
 
-with open("pom.xml", "r") as reader:
-    line = reader.readline()
-    while line:
+def uncomment(line: str):
+    if not line.lstrip().startswith("<!--"):
+        return line
+    return line.rstrip("\n").lstrip().lstrip("<!--").rstrip().rstrip("\n").rstrip("-->") + "\n"
 
-        if "<!-- spark 2.4 end -->" in line:
-            meet = False
 
-        if meet:
-            newlines.append("<!-- " + line.rstrip("\n") + " -->" + "\n")
+def comment(line: str):
+    if line.lstrip().startswith("<!--"):
+        return line
+    return "<!-- " + line.rstrip("\n") + " -->" + "\n"
 
-        if "<!-- spark 2.4 start -->" in line:
-            newlines.append(line)
-            meet = True
 
-        if "<!-- spark 3.0 end -->" in line:
-            meet1 = False
-            
-        if meet1:
-            newlines.append(line.lstrip().lstrip("<!--").rstrip().rstrip("\n").rstrip("-->") + "\n")
+def cleanLine(line: str) -> str:
+    return line.rstrip("\n").strip()
 
-        if "<!-- spark 3.0 start -->" in line:
-            newlines.append(line)
-            meet1 = True
-            
-        if not meet and not meet1:
-            newlines.append(line)
 
+def find(lines: List[str], start: int, start_tag: str, end_tag: str, stop_tag: str) -> (int, int):
+    _start = start
+    start_tag_index = -1
+    end_tag_index = -1
+    while _start < len(lines):
+        if cleanLine(lines[_start]) == "":
+            _start += 1
+            continue
+        if cleanLine(lines[_start]) == stop_tag:
+            break
+        if cleanLine(lines[_start]) == start_tag and end_tag_index == -1:
+            start_tag_index = _start
+
+        if cleanLine(lines[_start]) == end_tag and start_tag != -1:
+            end_tag_index = _start
+        _start += 1
+    return start_tag_index, end_tag_index
+
+
+def c_activation(path: str, target: str) -> NoReturn:
+    mapping = {
+        "scala-2.11": "2.4",
+        "scala-2.12": "3.0",
+        "spark-2.4.0": "2.4",
+        "spark-3.0.0": "3.0",
+        "streamingpro-spark-2.4.0-adaptor": "2.4",
+        "streamingpro-spark-3.0.0-adaptor": "3.0"
+    }
+    with open(path, "r") as reader:
+        lines = reader.readlines()
+
+        # scala-2.11 scala-2.12
+        # spark-2.4.0 spark-3.0.0
+        # streamingpro-spark-2.4.0-adaptor streamingpro-spark-3.0.0-adaptor
+        def find_target(lines: List[str], name):
+            index = 0
+            s = -1
+            e = -1
+            while index < len(lines):
+                if index < 4:
+                    index += 1
+                    continue
+                if f"<id>{name}</id>" in lines[index]:
+                    start_tag_index, end_tag_index = find(lines, index, "<activation>", "</activation>", "</profile>")
+                    # if no <activation> found, and we should add ,then set add pos
+                    if start_tag_index == -1 and target == mapping[name]:
+                        s = index
+                        break
+                    # if <activation> is found ,and we should remove, then set remove pos
+                    if start_tag_index != -1 and end_tag_index != -1 and target != mapping[name]:
+                        s = start_tag_index
+                        e = end_tag_index
+                        break
+                index += 1
+            return s, e
+
+        def add_replace(lines: List[str], s: int, e: int):
+
+            if s == -1 and e == -1:
+                return lines
+
+            newlines = []
+            # add
+            if s != -1 and e == -1:
+                for i in range(len(lines)):
+                    newlines.append(lines[i])
+                    if i == s:
+                        newlines.append('''
+                <activation>
+                    <activeByDefault>true</activeByDefault>
+                </activation>
+''')
+
+            # replace
+            if s != -1 and e != -1:
+                for i in range(len(lines)):
+                    if i < s or i > e:
+                        newlines.append(lines[i])
+            return newlines
+
+        s, e = find_target(lines, "scala-2.11")
+        newlines = add_replace(lines, s, e)
+
+        s, e = find_target(newlines, "scala-2.12")
+        newlines = add_replace(newlines, s, e)
+
+        s, e = find_target(newlines, "spark-2.4.0")
+        newlines = add_replace(newlines, s, e)
+
+        s, e = find_target(newlines, "spark-3.0.0")
+        newlines = add_replace(newlines, s, e)
+
+
+        s, e = find_target(newlines, "streamingpro-spark-2.4.0-adaptor")
+        newlines = add_replace(newlines, s, e)
+
+        s, e = find_target(newlines, "streamingpro-spark-3.0.0-adaptor")
+        newlines = add_replace(newlines, s, e)
+
+        with open(path, "w") as writer:
+            writer.writelines(newlines)
+
+
+def c_properties(path: str, target: str) -> NoReturn:
+    newlines = []
+
+    meet2_4 = False
+    meet3_0 = False
+
+    with open(path, "r") as reader:
         line = reader.readline()
+        while line:
 
-# for line in newlines:
-#     print(line)
-with open("pom.xml","w") as writer:
-    writer.writelines(newlines)
+            if "<!-- spark 2.4 end -->" in line:
+                meet2_4 = False
+
+            if meet2_4:
+                if target == "2.4":
+                    newlines.append(uncomment(line))
+                if target == "3.0":
+                    newlines.append(comment(line))
+
+            if "<!-- spark 2.4 start -->" in line:
+                newlines.append(line)
+                meet2_4 = True
+
+            if "<!-- spark 3.0 end -->" in line:
+                meet3_0 = False
+
+            if meet3_0:
+                if target == "2.4":
+                    newlines.append(comment(line))
+                if target == "3.0":
+                    newlines.append(uncomment(line))
+
+            if "<!-- spark 3.0 start -->" in line:
+                newlines.append(line)
+                meet3_0 = True
+
+            if not meet2_4 and not meet3_0:
+                newlines.append(line)
+
+            line = reader.readline()
+    with open(path, "w") as writer:
+        writer.writelines(newlines)
+
+
+target = 2.4
+if len(sys.argv) > 0:
+    target = sys.argv[1]
+for root, dirs, files in os.walk("."):
+    for file in files:
+        if file.endswith("pom.xml"):
+            file_path = os.path.join(root, file)
+            print(f"Apply {target} in  {file_path}")
+            c_properties(file_path, target)
+            c_activation(file_path, target)

--- a/dev/run-test.sh
+++ b/dev/run-test.sh
@@ -2,5 +2,18 @@
 ## example
 ## ./dev/run-test.sh
 
-mvn clean install -DskipTests
-mvn test -pl streamingpro-it
+V=${1:-2.4}
+
+if [ $V == "3.0" ];then
+   ./dev/change-scala-version.sh 2.12
+   python ./dev/python/convert_pom.py 3.0
+elif [ $V == "2.4" ]; then
+    ./dev/change-scala-version.sh 2.11
+   python ./dev/python/convert_pom.py 2.4
+else
+  echo "Only accept 2.4|3.0"
+  exit -1
+fi
+
+mvn clean install -DskipTests 
+mvn test  -pl streamingpro-it

--- a/dev/run-test.sh
+++ b/dev/run-test.sh
@@ -3,6 +3,7 @@
 ## ./dev/run-test.sh
 
 V=${1:-2.4}
+SKIP_INSTALL=${2:-NO}
 
 if [ $V == "3.0" ];then
    ./dev/change-scala-version.sh 2.12
@@ -15,5 +16,7 @@ else
   exit -1
 fi
 
-mvn clean install -DskipTests 
+if [ ${SKIP_INSTALL} != "skipInstall" ];then
+  mvn clean install -DskipTests
+fi
 mvn test  -pl streamingpro-it

--- a/dev/sync.sh
+++ b/dev/sync.sh
@@ -2,4 +2,4 @@ echo sync
 git co .
 git pull origin TRY  --no-edit  -X theirs
  ./dev/change-scala-version.sh 2.12
-python ./dev/python/convert_pom.py
+python ./dev/python/convert_pom.py 3.0

--- a/external/mlsql-autosuggest/pom.xml
+++ b/external/mlsql-autosuggest/pom.xml
@@ -8,9 +8,26 @@
         <version>2.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
-
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
+
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
+    
+
     <artifactId>mlsql-autosuggest-${spark.bigversion}_${scala.binary.version}</artifactId>
 
     <dependencies>

--- a/external/mlsql-ets/pom.xml
+++ b/external/mlsql-ets/pom.xml
@@ -9,6 +9,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
+
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>mlsql-ets-${spark.bigversion}_${scala.binary.version}</artifactId>
     <dependencies>
         <dependency>

--- a/external/mlsql-healthy/pom.xml
+++ b/external/mlsql-healthy/pom.xml
@@ -9,7 +9,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>mlsql-healthy-${spark.bigversion}_${scala.binary.version}</artifactId>
 
     <dependencies>

--- a/external/mlsql-lang/pom.xml
+++ b/external/mlsql-lang/pom.xml
@@ -9,7 +9,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>mlsql-lang-${spark.bigversion}_${scala.binary.version}</artifactId>
 
     <dependencies>

--- a/external/mlsql-mysql-store/pom.xml
+++ b/external/mlsql-mysql-store/pom.xml
@@ -9,7 +9,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>mlsql-mysql-store-${spark.bigversion}_${scala.binary.version}</artifactId>
 
     <dependencies>

--- a/external/mlsql-sql-profiler-30/pom.xml
+++ b/external/mlsql-sql-profiler-30/pom.xml
@@ -9,7 +9,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>mlsql-sql-profiler-30-${spark.bigversion}_${scala.binary.version}</artifactId>
     <dependencies>
         <dependency>

--- a/external/mlsql-sql-profiler/pom.xml
+++ b/external/mlsql-sql-profiler/pom.xml
@@ -9,7 +9,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>mlsql-sql-profiler-${spark.bigversion}_${scala.binary.version}</artifactId>
     <dependencies>
         <dependency>

--- a/external/mlsql-watcher/pom.xml
+++ b/external/mlsql-watcher/pom.xml
@@ -9,7 +9,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>mlsql-watcher-${spark.bigversion}_${scala.binary.version}</artifactId>
     <dependencies>
 

--- a/external/python-controller/pom.xml
+++ b/external/python-controller/pom.xml
@@ -9,7 +9,23 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>python-controller-${spark.bigversion}_${scala.binary.version}</artifactId>
 
     <dependencies>

--- a/streamingpro-cluster/pom.xml
+++ b/streamingpro-cluster/pom.xml
@@ -8,7 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-cluster-${spark.bigversion}_${scala.binary.version}</artifactId>
     <profiles>
         <profile>

--- a/streamingpro-commons/pom.xml
+++ b/streamingpro-commons/pom.xml
@@ -8,7 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-common-${spark.bigversion}_${scala.binary.version}</artifactId>
     <dependencies>
         <dependency>

--- a/streamingpro-core/pom.xml
+++ b/streamingpro-core/pom.xml
@@ -8,7 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-core-${spark.bigversion}_${scala.binary.version}</artifactId>
     <dependencies>
         <dependency>

--- a/streamingpro-dsl/pom.xml
+++ b/streamingpro-dsl/pom.xml
@@ -8,7 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-dsl-${spark.bigversion}_${scala.binary.version}</artifactId>
     <dependencies>
         <dependency>

--- a/streamingpro-it/pom.xml
+++ b/streamingpro-it/pom.xml
@@ -8,18 +8,40 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <properties>
         <breeze-version>0.13.2</breeze-version>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
+
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+
     </properties>
 
-    <artifactId>streamingpro-it</artifactId>
+    <artifactId>streamingpro-it-${spark.bigversion}_${scala.binary.version}</artifactId>
+    
     <dependencies>
 
         <dependency>
             <groupId>tech.mlsql</groupId>
             <artifactId>streamingpro-mlsql-spark_${spark.bigversion}_${scala.binary.version}</artifactId>
             <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
         </dependency>
 
         <dependency>

--- a/streamingpro-mlsql/pom.xml
+++ b/streamingpro-mlsql/pom.xml
@@ -8,7 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-mlsql-spark_${spark.bigversion}_${scala.binary.version}</artifactId>
     <profiles>
         

--- a/streamingpro-spark-2.3.0-adaptor/pom.xml
+++ b/streamingpro-spark-2.3.0-adaptor/pom.xml
@@ -8,7 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-spark-2.3.0-adaptor_${scala.binary.version}</artifactId>
     <dependencies>
 

--- a/streamingpro-spark-2.4.0-adaptor/pom.xml
+++ b/streamingpro-spark-2.4.0-adaptor/pom.xml
@@ -8,7 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-spark-2.4.0-adaptor_${scala.binary.version}</artifactId>
 
     <dependencies>

--- a/streamingpro-spark-3.0.0-adaptor/pom.xml
+++ b/streamingpro-spark-3.0.0-adaptor/pom.xml
@@ -8,7 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
 
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-spark-3.0.0-adaptor_${scala.binary.version}</artifactId>
 
     <dependencies>

--- a/streamingpro-spark-common/pom.xml
+++ b/streamingpro-spark-common/pom.xml
@@ -8,6 +8,23 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <!-- spark 2.4 start -->
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.3</spark.version>
+        <spark.bigversion>2.4</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
+        <!-- spark 2.4 end -->
+
+        <!-- spark 3.0 start -->
+        <!--        <scala.version>2.12.10</scala.version> -->
+        <!--        <scala.binary.version>2.12</scala.binary.version> -->
+        <!--        <spark.version>3.1.1</spark.version> -->
+        <!--        <spark.bigversion>3.0</spark.bigversion> -->
+        <!--        <scalatest.version>3.0.3</scalatest.version> -->
+        <!-- spark 3.0 end -->
+    </properties>
     <artifactId>streamingpro-spark-common-${spark.bigversion}_${scala.binary.version}</artifactId>
     <dependencies>
         <dependency>


### PR DESCRIPTION
# What changes were proposed in this pull request?
Since `streamingpro-it` module depends `streamingpro-mlsql`, but `streamingpro-mlsql` use variable/profile in pom which will  make 
it cannot resolve the dependencies correctly. We add some properties/activation in every pom and this properties will be changed with the script run-test.sh. 

# How was this patch tested?
- Now you can run  ./dev/run-test.sh 2.4|3.0  to test spark 2.4.3 and 3.1.1 serperately.
- Notice that you should have python 3 installed in your system in order  to run run-test.sh

# Are there and DOC need to update?
- No Doc

# Spark Core Compatibility

- No Change
