### PR TITLE
https://github.com/allwefantasy/mlsql/issues/1518

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -61,20 +61,23 @@ ENABLE_JYTHON ${ENABLE_JYTHON}
 ENABLE_CHINESE_ANALYZER ${ENABLE_CHINESE_ANALYZER}
 ENABLE_HIVE_THRIFT_SERVER ${ENABLE_HIVE_THRIFT_SERVER}"
 
-SELF=$(cd $(dirname $0) && pwd)
-cd $SELF
+## Change directory to mlsql base directory
+base=$(cd $(dirname $0)/.. && pwd)
+cd $base/
 
-if [[ ${MLSQL_SPARK_VERSION} = "2.3" || ${MLSQL_SPARK_VERSION} = "2.4" ]]
+## Needs to call convert_pom.py from ${base} directory
+if [[ ${MLSQL_SPARK_VERSION} == "2.4" ]]
 then
-  ./change-scala-version.sh 2.11
-elif [[ ${MLSQL_SPARK_VERSION} = "3.0" ]]
+  ./dev/change-scala-version.sh 2.11
+  python ./dev/python/convert_pom.py 2.4
+elif [[ ${MLSQL_SPARK_VERSION} == "3.0" ]]
 then
-  ./change-scala-version.sh 2.12
+  ./dev/change-scala-version.sh 2.12
+  python ./dev/python/convert_pom.py 3.0
 else
   echo "Spark-${MLSQL_SPARK_VERSION} is not supported"
   exit_with_usage
-  exit 1
 fi
 
 ## Start building
-./package.sh
+./dev/package.sh

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/example/app/LoalSparkServiceApp.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/example/app/LoalSparkServiceApp.scala
@@ -6,62 +6,18 @@ import streaming.core.StreamingApp
  * 2019-03-20 WilliamZhu(allwefantasy@gmail.com)
  */
 object LocalSparkServiceApp {
+
   def main(args: Array[String]): Unit = {
     StreamingApp.main(Array(
       "-streaming.master", "local[*]",
-      "-streaming.name", "god",
+      "-streaming.name", "Mlsql-desktop",
       "-streaming.rest", "true",
       "-streaming.thrift", "false",
       "-streaming.platform", "spark",
-      "-spark.mlsql.enable.runtime.directQuery.auth", "true",
-      //      "-streaming.ps.cluster.enable","false",
-      "-streaming.enableHiveSupport", "false",
-      "-spark.mlsql.datalake.overwrite.hive", "true",
-      "-spark.mlsql.auth.access_token", "mlsql",
-      "-spark.hadoop.parquet.strings.signed-min-max.enabled", "true",
-      //"-spark.mlsql.enable.max.result.limit", "true",
-      //"-spark.mlsql.restful.api.max.result.size", "7",
-      //      "-spark.mlsql.enable.datasource.rewrite", "true",
-      //      "-spark.mlsql.datasource.rewrite.implClass", "streaming.core.datasource.impl.TestRewrite",
-      //"-streaming.job.file.path", "classpath:///test/init.json",
       "-streaming.spark.service", "true",
       "-streaming.job.cancel", "true",
-      "-streaming.datalake.path", "/Users/allwefantasy/data/mlsql/datalake/",
-
-      //      "-streaming.plugin.clzznames","tech.mlsql.plugins.ds.MLSQLExcelApp",
-
-      // scheduler
-      "-streaming.workAs.schedulerService", "false",
-      "-streaming.workAs.schedulerService.consoleUrl", "http://127.0.0.1:9002",
-      "-streaming.workAs.schedulerService.consoleToken", "mlsql",
-
-
-      //      "-spark.sql.hive.thriftServer.singleSession", "true",
-      "-streaming.rest.intercept.clzz", "streaming.rest.ExampleRestInterceptor",
-      //      "-streaming.deploy.rest.api", "true",
-      "-spark.driver.maxResultSize", "2g",
-      "-spark.serializer", "org.apache.spark.serializer.KryoSerializer",
-      //      "-spark.sql.codegen.wholeStage", "true",
-      "-spark.ui.allowFramingFrom", "*",
-      "-spark.kryoserializer.buffer.max", "2000m",
+      "-streaming.datalake.path", "./data/",
       "-streaming.driver.port", "9003"
-      //      "-spark.files.maxPartitionBytes", "10485760"
-
-      //meta store
-      //      "-streaming.metastore.db.type", "mysql",
-      //      "-streaming.metastore.db.name", "app_runtime_full",
-      //      "-streaming.metastore.db.config.path", "./__mlsql__/db.yml"
-
-      //      "-spark.sql.shuffle.partitions", "1",
-      //      "-spark.hadoop.mapreduce.job.run-local", "true"
-
-      //"-streaming.sql.out.path","file:///tmp/test/pdate=20160809"
-
-      //"-streaming.jobs","idf-compute"
-      //"-streaming.sql.source.path","hdfs://m2:8020/data/raw/live-hls-formated/20160725/19/cdn148-16-52_2016072519.1469444764341"
-      //"-streaming.driver.port", "9005"
-      //"-streaming.zk.servers", "127.0.0.1",
-      //"-streaming.zk.conf_root_dir", "/streamingpro/jack"
-    ))
+    ) ++ args )
   }
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
- LocalSparkServiceApp supports mlsql options passed in as argument.
- make-distribution.sh now calls convert_pom.py before building 

# How was this patch tested?
- Successfully run with spark 3.1.1 and 2.4.3 
- All cases in streaming-it  passed.

# Are there and DOC need to update?
No doc change is required.

# Spark Core Compatibility
- Spark 3.1.1 OK
- Spark 2.4.3 OK