### PR TITLE
Modify DriverLogServer to HTTP

### DIFF
--- a/streamingpro-core/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
+++ b/streamingpro-core/src/main/java/org/apache/spark/ps/cluster/PSExecutorBackend.scala
@@ -2,7 +2,6 @@ package org.apache.spark.ps.cluster
 
 import java.net.URL
 import java.util.Locale
-
 import _root_.streaming.core.strategy.platform.{PlatformManager, SparkRuntime}
 import org.apache.spark._
 import org.apache.spark.api.MLSQLExecutorPlugin
@@ -12,7 +11,7 @@ import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.security.CryptoStreamUtils
 import org.apache.spark.util.ThreadUtils
 import tech.mlsql.common.utils.exception.ExceptionTool
-import tech.mlsql.log.WriteLog
+import tech.mlsql.log.BaseHttpLogClient
 import tech.mlsql.nativelib.runtime.MLSQLNativeRuntime
 import tech.mlsql.python.BasicCondaEnvManager
 import tech.mlsql.tool.HDFSOperatorV2
@@ -216,7 +215,7 @@ class PSExecutorPlugin(conf: SparkConf) extends MLSQLExecutorPlugin with Logging
   override def _init(config: Map[Any, Any]): Unit = {
     logInfo("PSExecutorPlugin starting.....")
     try {
-      WriteLog.init(conf.getAll.toMap)
+      BaseHttpLogClient.init(conf.getAll.toMap)
     } catch {
       case e: Exception => logInfo("Fail to connect DriverLogServer", e)
     }

--- a/streamingpro-core/src/main/java/tech/mlsql/log/BaseHttpLogClient.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/log/BaseHttpLogClient.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.mlsql.log
+
+import org.apache.http.client.fluent.Request
+import org.apache.http.entity.ContentType
+import streaming.log.WowLog
+import tech.mlsql.arrow.python.runner.PythonConf
+import tech.mlsql.common.utils.lang.sc.ScalaMethodMacros
+import tech.mlsql.common.utils.log.Logging
+import tech.mlsql.common.utils.net.NetTool
+
+trait BaseHttpLogClient extends Logging with WowLog {
+
+  val _conf: Map[String, String] = BaseHttpLogClient.conf
+
+  def write(iter: Iterator[String], params: Map[String, String]): Unit = {
+    val owner = params.getOrElse(ScalaMethodMacros.str(PythonConf.PY_EXECUTE_USER), "")
+    val groupId = params.getOrElse("groupId", "")
+    try {
+      val url = _conf.getOrElse("spark.mlsql.log.driver.url", NetTool.localHostNameForURI())
+      val token = _conf.getOrElse("spark.mlsql.log.driver.token", "mlsql")
+      iter.foreach { line =>
+        val body = SendLog(token, LogUtils.formatWithOwner(line, owner, groupId)).json
+        Request.Post(url).bodyString(body, ContentType.APPLICATION_JSON.withCharset("utf8"))
+          .addHeader("Content-Type", "application/x-www-form-urlencoded")
+          .execute()
+      }
+
+    } catch {
+      case e: Exception =>
+        logError(LogUtils.formatWithOwner(s"Failed to write log on client side!", owner, groupId), e)
+    }
+  }
+
+}
+
+object BaseHttpLogClient {
+  var conf: Map[String, String] = _
+
+  def init(conf: Map[String, String]): Any = {
+    this.conf = conf
+  }
+}

--- a/streamingpro-core/src/main/java/tech/mlsql/log/BaseHttpLogServer.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/log/BaseHttpLogServer.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.mlsql.log
+
+import org.apache.spark.{MLSQLSparkUtils, SparkEnv}
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.handler.AbstractHandler
+import tech.mlsql.common.utils.distribute.socket.server.{Request, Response}
+import tech.mlsql.common.utils.net.NetTool
+
+trait BaseHttpLogServer extends AbstractHandler {
+
+  var requestMapping: String
+  var url: String = _
+  var host: String = _
+  var port: Int = _
+  var server: Server = _
+
+  def init(host: String, port: Int): (Server, String, String, Int)
+
+  def build(host: String, port: Int): Boolean = {
+    val (_server, _url, _host, _port) = init(host, port)
+    this.server = _server
+    this.url = _url
+    this.host = _host
+    this.port = _port
+    server.isStarting || server.isStarted
+  }
+
+  def close(): Unit
+
+  def getHost: String = {
+    if (SparkEnv.get == null || MLSQLSparkUtils.rpcEnv().address == null) NetTool.localHostName()
+    else MLSQLSparkUtils.rpcEnv().address.host
+  }
+
+}
+
+case class SendLog(token: String, logLine: String) extends Request[LogRequest] {
+  override def wrap = LogRequest(sendLog = this)
+}
+
+case class StopSendLog() extends Request[LogRequest] {
+  override def wrap = LogRequest(stopSendLog = this)
+}
+
+case class Ok() extends Response[LogResponse] {
+  override def wrap = LogResponse(ok = this)
+}
+
+case class Negative() extends Response[LogResponse] {
+  override def wrap = LogResponse(negative = this)
+}
+
+case class LogResponse(
+                        ok: Ok = null,
+                        negative: Negative = null
+                      ) {
+  def unwrap: Response[_] = {
+    if (ok != null) ok
+    else if (negative != null) negative
+    else null
+  }
+}
+
+case class LogRequest(sendLog: SendLog = null, stopSendLog: StopSendLog = null) {
+  def unwrap: Request[_] = {
+    if (sendLog != null) sendLog
+    else if (stopSendLog != null) stopSendLog
+    else null
+  }
+}


### PR DESCRIPTION
# background
MLSQL Engine is a typical distributed system with a master-slave structure. Because it is multi-tenant and programmable (such as printing with Print in python), these need to be displayed on the web page, and only the logs related to this user are echoed. And now the log system has the following problems:
1. Using Socket connection will cause too many socket connections on the driver side.
2. At present, the log received by the driver is written into the log file, and then the log file will be read through the driver to filter out the logs required by the user.

# Expected goal
1. MLSQL log collection is transformed to HTTP
2. Plug-in log collection, allowing different implementations to be configured.

# Technical solutions
## 1. MLSQL log interface transformation
### 1.1 HTTPClient fluent API pre-research (on the scala side)
View the flow of auth module using fluent API

### 1.2 Python uses its own request library

### 1.3 socket replaced with HTTP
 > Use http fluent api as a short connection to receive executor logs
1) Transform DriverLogServer into HTTPServer
2) The DriverLogServer in SparkRuntime.scala is modified to be obtained by reflection, and set to option to support configuration.
Previously, the fixed option in `SparkRuntime.scala`:
```
spark.mlsql.log.driver.host
spark.mlsql.log.driver.port
spark.mlsql.log.driver.token
```

Option to be transformed:
```
-spark.mlsql.log.driver.server.implClass  # The default is tech.mlsql.log.DriverLogServer

-spark.mlsql.log.driver.url # Get the local host of the driver by default: port/api_v1/writelog, port is generated by yourself

-spark.mlsql.log.driver.host # The default is local ip

-spark.mlsql.log.driver.port # The default is 0, choose a random port

-spark.mlsql.log.driver.token # The request header parameter accessToken is UUID; Worker will get it from spark conf and compare whether the access_token carried in the request is legal
```

Refer to several options used by Auth:
```
1. Startup configuration items:
-spark.mlsql.auth.implClass: streaming.dsl.auth.client.DefaultConsoleClient

2. userDefinedParam:
__auth_server_url__: Configured for the Engine settings configuration page of the Console, the field is consoleUrl
__auth_secret__: Configured for the Engine settings configuration page of the Console, the field is accessToken

3. Settings configuration items in `application.yml`:
auth_secret: "mlsql"
```

3) WriteLog in `RedirectStreamsToSocketServer.scala` is a socket thread, and the log consumption thread here needs to be changed to HTTP.

4) HTTP transformation on Python side
The python side is divided into two log output methods, one is processed by the scala code in the Executor through the standard output stream and the exception stream, and the other is through the LogClient.
-The first type does not require modification, and the modification point is on the scala side
-The second, you need to change the LogClient in the mlsql.py script to HTTP (you need to confirm whether there is a difference between the daemon and worker methods)