### PR TITLE
MLSQL integration testing needs to support Python environment

### DIFF
--- a/streamingpro-it/src/test/resources/sql/simple/00_init_python_env.mlsql
+++ b/streamingpro-it/src/test/resources/sql/simple/00_init_python_env.mlsql
@@ -1,0 +1,31 @@
+--%comparator=tech.mlsql.it.IgnoreResultComparator
+-- !plugin app add - "mlsql-shell-2.4";
+
+!sh script '''
+conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/msys2/
+conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge/
+conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
+conda init
+source activate
+conda deactivate
+if test -z "$(conda env list |grep it_env)"; then
+    echo "Start to create a conda environment with python version 3.6.7: it_env..."
+    conda create --name it_env python=3.6.7
+    echo "The conda environment is created."
+else
+    echo "Conda environment already exists."
+fi
+conda activate it_env
+echo "Start to install pip dependencies..."
+pip config set global.trusted-host  mirrors.aliyun.com
+pip config set global.index-url http://mirrors.aliyun.com/pypi/simple/
+pip install Cython
+pip install pytest-runner
+pip install pyarrow==4.0.1
+pip install ray==1.3.0
+pip install aiohttp psutil grpcio pandas xlsxwriter
+pip install watchdog requests click uuid sfcli  pyjava vega_datasets
+pip install plotly
+pip install aioredis==1.3.1
+echo "Conda environment initialization is complete!"
+''';

--- a/streamingpro-it/src/test/resources/sql/simple/12_log_client_test.mlsql
+++ b/streamingpro-it/src/test/resources/sql/simple/12_log_client_test.mlsql
@@ -1,0 +1,12 @@
+--%comparator=tech.mlsql.it.IgnoreResultComparator
+!python env "PYTHON_ENV=source activate it_env";
+!python conf "schema=st(field(petalLength,double),field(petalWidth,double),field(sepalLength,double),field(sepalWidth,double),field(species,string))";
+!python conf "dataMode=model";
+
+!ray on command '''
+import time
+
+for i in range(5):
+    print("---log_client msg1--")
+    context.log_client.log_to_driver("---log_client msg2--")
+''' named mlsql_temp_table;

--- a/streamingpro-it/src/test/scala/tech/mlsql/it/LocalBaseTestSuite.scala
+++ b/streamingpro-it/src/test/scala/tech/mlsql/it/LocalBaseTestSuite.scala
@@ -19,7 +19,7 @@ trait LocalBaseTestSuite extends FunSuite with SparkOperationUtil with BeforeAnd
   var dataDirPath: String = _
   var home: String = _
   val user = "admin"
-  var initialPlugins: Seq[String] = Seq("mlsql-assert")
+  var initialPlugins: Seq[String] = Seq("mlsql-assert", "mlsql-shell")
   var originClassLoader = Thread.currentThread().getContextClassLoader
 
   def initPlugins(): Unit = {


### PR DESCRIPTION
# Solution one, use PythonEnvExt ET plugin
After investigation, I found that MLSQL supports SQL to create a Python environment. We only need to prepare a configuration in yaml format, and a conda virtual environment will be generated through ET PythonEnvExt. Among them, command="name" means to get the name of the environment generated by the yaml file, so that we can switch to the created environment through source activate ${envName}. The creation script is as follows:
```
set user="admin";
set dependencies='''
name: it_env
dependencies:
  -python=3.6.7
  -pip
  -pip:
    ---trusted-host mirrors.aliyun.com
    ---index-url https://mirrors.aliyun.com/pypi/simple/
    -pytest-runner
    -Cython
    -pyarrow==4.0.1
    -aiohttp
    -psutil
    -grpcio
    -pandas
    -xlsxwriter
    -watchdog
    -requests
    -click
    -uuid
    -sfcli
    -pyjava
    -aioredis==1.3.1
''';

load script.`dependencies` as dependencies;

run command as PythonEnvExt.`/tmp/${user}` where condaFile="dependencies" and command="create";

run command as PythonEnvExt.`/tmp/${user}` where condaFile="dependencies" and command="name" as envTable;

set envName=`select * from envTable as output` where type="sql";

set env=`$(conda info -e | grep ${envName} |awk -F'[ ]+''{print $2"/bin/pip install ray==1.3.0"}')` where type=" shell";

select "${envName}" as a as b;
```

## pip install in 2 steps
The above script installs the python module in 2 steps. The reason why they are not put together is that the ray module depends on pytest-runner, and the installation order of pip in yaml is out of order. Even if ray is placed at the end, it will have a better chance than pytest-runner. Install first, so it is split below.
The second solution is to modify the PythonEnvExt installation pip to be orderly, but even if the order is tested, it is found that the installation speed of dependencies is very slow, and installation failures often lead to tasks that are stuck and do not end. It is not recommended to put a lot of installation modules here.

## Obtain conda environment through script
Here, the location of pip is obtained by conda info -e, instead of using source activate ${envName}, because source activate is not supported in scala ShellCommand, an error will be reported

# Solution two, use shell ET plug-in
```
!sh script '''
conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/msys2/
conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge/
conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
conda init
source activate
conda deactivate
if test -z "$(conda env list |grep it_env)"; then
    echo "Start to create a conda environment with python version 3.6.7: it_env..."
    conda create --name it_env python=3.6.7
    echo "The conda environment is created."
else
    echo "Conda environment already exists."
fi
conda activate it_env
echo "Start to install pip dependencies..."
pip config set global.trusted-host  mirrors.aliyun.com
pip config set global.index-url http://mirrors.aliyun.com/pypi/simple/
pip install Cython
pip install pytest-runner
pip install pyarrow==4.0.1
pip install ray==1.3.0
pip install aiohttp psutil grpcio pandas xlsxwriter
pip install watchdog requests click uuid sfcli  pyjava vega_datasets
pip install plotly
pip install aioredis==1.3.1
echo "Conda environment initialization is complete!"
''';
```

The second solution is more flexible. At the same time, we can avoid some problems such as pip out-of-order installation encountered above. Develop in this way.