### PR TITLE
Fix the bug that the spark executor plugin cannot be loaded, in spark3+.

### DIFF
--- a/streamingpro-spark-3.0.0-adaptor/src/main/java/org/apache/spark/api/MLSQLExecutorPlugin.scala
+++ b/streamingpro-spark-3.0.0-adaptor/src/main/java/org/apache/spark/api/MLSQLExecutorPlugin.scala
@@ -1,20 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.api
 
 import _root_.java.util
-import org.apache.spark.api.plugin.{ExecutorPlugin, PluginContext}
+import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 
 /**
  * The parameters in init method are different in different version of Spark.
  * We make sure finally the implementation can hold all parameters, and we can handle the
- * differences. 
+ * differences.
  */
-trait MLSQLExecutorPlugin extends ExecutorPlugin {
-  override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = _init(Map[Any, Any]())
+trait MLSQLExecutorPlugin extends SparkPlugin {
 
-  override def shutdown(): Unit = _shutdown()
+  override def driverPlugin(): DriverPlugin = null
+
+  override def executorPlugin(): ExecutorPlugin = new ExecutorPlugin {
+    override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = _init(Map[Any, Any]())
+
+    override def shutdown(): Unit = _shutdown()
+  }
 
   def _init(config: Map[Any, Any]): Unit
 
   def _shutdown(): Unit
+
 }
 


### PR DESCRIPTION
The org.apache.spark.ExecutorPlugin interface and related configuration has been replaced with org.apache.spark.api.plugin.SparkPlugin, which adds new functionality. Plugins using the old interface must be modified to extend the new interfaces. Check the Monitoring guide for more details.