### PR TITLE
Use urlendcode format log

### DIFF
--- a/streamingpro-core/src/main/java/tech/mlsql/log/BaseHttpLogClient.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/log/BaseHttpLogClient.scala
@@ -44,8 +44,8 @@ trait BaseHttpLogClient extends Logging with WowLog {
       val token = _conf.getOrElse("spark.mlsql.log.driver.token", "mlsql")
       iter.foreach { line =>
         val body = SendLog(token, LogUtils.formatWithOwner(line, owner, groupId)).json
-        Request.Post(url).addHeader("Content-Type", "application/x-www-form-urlencoded")
-          .bodyForm(Form.form().add(body, null).build())
+        Request.Post(url).addHeader("Content-Type", "application/json")
+          .bodyString(body, ContentType.APPLICATION_JSON.withCharset("utf8"))
           .execute()
       }
 

--- a/streamingpro-core/src/main/java/tech/mlsql/log/BaseHttpLogClient.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/log/BaseHttpLogClient.scala
@@ -18,7 +18,7 @@
 
 package tech.mlsql.log
 
-import org.apache.http.client.fluent.Request
+import org.apache.http.client.fluent.{Form, Request}
 import org.apache.http.entity.ContentType
 import org.apache.spark.SparkEnv
 import streaming.log.WowLog
@@ -44,8 +44,8 @@ trait BaseHttpLogClient extends Logging with WowLog {
       val token = _conf.getOrElse("spark.mlsql.log.driver.token", "mlsql")
       iter.foreach { line =>
         val body = SendLog(token, LogUtils.formatWithOwner(line, owner, groupId)).json
-        Request.Post(url).bodyString(body, ContentType.APPLICATION_JSON.withCharset("utf8"))
-          .addHeader("Content-Type", "application/x-www-form-urlencoded")
+        Request.Post(url).addHeader("Content-Type", "application/x-www-form-urlencoded")
+          .bodyForm(Form.form().add(body, null).build())
           .execute()
       }
 


### PR DESCRIPTION
# Problem Description:
When I tested in the morning, I found that the "=" or "&" in the request data would cause the log display to be incomplete. It was located because the encoding method of sending data in fluemt is: Content-Type=application/x-www-form-urlencoded format, This format requires the data to be encoded in the way of key1=val1&key2=val2. If there is a "=" separator, it will be split into multiple sets of parameters, and I only took the first set of json text data in jetty.

# solution:
Urlencode the log with special characters