### PR TITLE
support regex to run test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ external/mlsql-native-operators/build/
 *.tgz
 
 streamingpro-it/src/test/home/
+gc.log.*

--- a/dev/run-test.sh
+++ b/dev/run-test.sh
@@ -2,8 +2,10 @@
 ## example
 ## ./dev/run-test.sh
 
-V=${1:-2.4}
+V=${1:-3.0}
 SKIP_INSTALL=${2:-NO}
+MATCHES=${3:-.*}
+
 
 if [ $V == "3.0" ];then
    ./dev/change-scala-version.sh 2.12
@@ -21,4 +23,6 @@ mvn clean
 if [ ${SKIP_INSTALL} != "skipInstall" ];then
   mvn clean install -DskipTests
 fi
-mvn test  -pl streamingpro-it
+
+
+mvn test -pl streamingpro-it "-DargLine=-Dmatches=${MATCHES}"


### PR DESCRIPTION
# What changes were proposed in this pull request?

With this PR, we can run the specified tests.  We can run tests like following:

```shell
./dev/run-test.sh 3.0 skipInstall "^13.*"
```

The first parameter means we run the tests in core 3
the second parameter means without installing all module 
the third parameter means only run the tests match regex "^13.*".

# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
