### PR TITLE
[ET] fix param values of ET

### DIFF
--- a/external/mlsql-ets/src/main/java/tech/mlsql/plugins/ets/TableRepartition.scala
+++ b/external/mlsql-ets/src/main/java/tech/mlsql/plugins/ets/TableRepartition.scala
@@ -199,7 +199,7 @@ class TableRepartition(override val uid: String) extends SQLAlg with VersionComp
           """,
         label = "Number of repartition",
         options = Map(
-          "valueType" -> "string",
+          "valueType" -> "int",
           "defaultValue" -> "",
           "required" -> "true",
           "derivedType" -> "NONE"

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLSendMessage.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLSendMessage.scala
@@ -207,12 +207,14 @@ class SQLSendMessage(override val uid: String) extends SQLAlg with Functions wit
           "required" -> "true",
           "derivedType" -> "NONE"
         )), valueProvider = Option(() => {
-        List(KV(Option("mailType"), Option("config")))
-        List(KV(Option("mailType"), Option("local_server")))
+        List(KV(Option("mailType"), Option("config")),
+          KV(Option("mailType"), Option("local")))
       })
     )
     )
   )
+  setDefault(mailType, "config")
+
   val userName: Param[String] = new Param[String](this, "userName",
     FormParams.toJson(Dynamic(
       name = "userName",
@@ -247,7 +249,7 @@ class SQLSendMessage(override val uid: String) extends SQLAlg with Functions wit
       valueProviderName = ""
     )
     ))
-  setDefault(mailType, "config")
+
   val content: Param[String] = new Param[String](this, "content",
     FormParams.toJson(Text(
       name = "content",
@@ -283,12 +285,13 @@ class SQLSendMessage(override val uid: String) extends SQLAlg with Functions wit
           "required" -> "false",
           "derivedType" -> "NONE"
         )), valueProvider = Option(() => {
-        List(KV(Option("contentType"), Option(MailContentTypeEnum.MIXED.toString)))
-        List(KV(Option("contentType"), Option(MailContentTypeEnum.TEXT.toString)))
-        List(KV(Option("contentType"), Option(MailContentTypeEnum.HTML.toString)))
-        List(KV(Option("contentType"), Option(MailContentTypeEnum.CSV.toString)))
-        List(KV(Option("contentType"), Option(MailContentTypeEnum.JPEG.toString)))
-        List(KV(Option("contentType"), Option(MailContentTypeEnum.DEFAULT_ATTACHMENT.toString)))
+        List(KV(Option("contentType"), Option(MailContentTypeEnum.MIXED.toString)),
+          KV(Option("contentType"), Option(MailContentTypeEnum.TEXT.toString)),
+          KV(Option("contentType"), Option(MailContentTypeEnum.HTML.toString)),
+          KV(Option("contentType"), Option(MailContentTypeEnum.CSV.toString)),
+          KV(Option("contentType"), Option(MailContentTypeEnum.JPEG.toString)),
+          KV(Option("contentType"), Option(MailContentTypeEnum.DEFAULT_ATTACHMENT.toString))
+        )
       })
     )
     )
@@ -309,12 +312,12 @@ class SQLSendMessage(override val uid: String) extends SQLAlg with Functions wit
           "required" -> "false",
           "derivedType" -> "NONE"
         )), valueProvider = Option(() => {
-        List(KV(Option("attachmentContentType"), Option(MailContentTypeEnum.MIXED.toString)))
-        List(KV(Option("attachmentContentType"), Option(MailContentTypeEnum.TEXT.toString)))
-        List(KV(Option("attachmentContentType"), Option(MailContentTypeEnum.HTML.toString)))
-        List(KV(Option("attachmentContentType"), Option(MailContentTypeEnum.CSV.toString)))
-        List(KV(Option("attachmentContentType"), Option(MailContentTypeEnum.JPEG.toString)))
-        List(KV(Option("attachmentContentType"), Option(MailContentTypeEnum.DEFAULT_ATTACHMENT.toString)))
+        List(KV(Option("attachmentContentType"), Option(MailContentTypeEnum.MIXED.toString)),
+          KV(Option("attachmentContentType"), Option(MailContentTypeEnum.TEXT.toString)),
+          KV(Option("attachmentContentType"), Option(MailContentTypeEnum.HTML.toString)),
+          KV(Option("attachmentContentType"), Option(MailContentTypeEnum.CSV.toString)),
+          KV(Option("attachmentContentType"), Option(MailContentTypeEnum.JPEG.toString)),
+          KV(Option("attachmentContentType"), Option(MailContentTypeEnum.DEFAULT_ATTACHMENT.toString)))
       })
     )
     )
@@ -441,12 +444,11 @@ class SQLSendMessage(override val uid: String) extends SQLAlg with Functions wit
       | set EMAIL_BODY = "body";
       | set EMAIL_TO = "do_not_reply@gmail.com";
       |
-      | select "${EMAIL_BODY}" as content as data;
-      |
       |- Use the configuration account method
-      |run data as SendMessage.``
+      |run command as SendMessage.``
       |where method="mail"
       |and from = "do_not_reply@gmail.com"
+      |and content = "${EMAIL_BODY}"
       |and to = "${EMAIL_TO}"
       |and subject = "${EMAIL_TITLE}"
       |and smtpHost = "smtp.gmail.com"
@@ -462,6 +464,7 @@ class SQLSendMessage(override val uid: String) extends SQLAlg with Functions wit
       |run data as SendMessage.``
       |where method="mail"
       | and `mailType`="local"
+      |and content = "${EMAIL_BODY}"
       | and from = "do_not_reply@gmail.com"
       | and to = "${EMAIL_TO}"
       | and subject = "${EMAIL_TITLE}"
@@ -473,6 +476,33 @@ class SQLSendMessage(override val uid: String) extends SQLAlg with Functions wit
       | ```
       | Email sent successfully!
       | ```
+      | 
+      |- Below we introduce how to use email to send HTML formatted text and carry attachments.
+      |
+      |1) First, upload two CSV files `employee.csv` and `company.csv` through MLSQL Api Console as attachment content.
+      |
+      |2) Then, send the email through the following SQL, an example is shown below:
+      |
+      |```sql
+      |set EMAIL_TITLE = "This is the title of the email";
+      |set EMAIL_BODY ='''<div>This is the first line</div><br/><hr/><div>This is the second line</div>''';
+      |set EMAIL_TO = "137297351@qq.com";
+      |
+      |run command as SendMessage.
+      |where method="mail"
+      |and content="${EMAIL_BODY}"
+      |and from = "137297351@qq.com"
+      |and to = "${EMAIL_TO}"
+      |and subject = "${EMAIL_TITLE}"
+      |and contentType="text/html"
+      |and attachmentContentType="text/csv"
+      |and attachmentPaths="/tmp/employee.csv,/tmp/employee.csv"
+      |and smtpHost = "smtp.qq.com"
+      |and smtpPort="587"
+      |and `userName`="137297351@qq.com"
+      |and password="---"
+      |;
+      |```
       |""".stripMargin)
 }
 

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLTreeBuildExt.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLTreeBuildExt.scala
@@ -334,8 +334,8 @@ class SQLTreeBuildExt(override val uid: String) extends SQLAlg with Functions wi
           "required" -> "false",
           "derivedType" -> "NONE"
         )), valueProvider = Option(() => {
-        List(KV(Option("treeType"), Option("treePerRow")))
-        List(KV(Option("treeType"), Option("nodeTreePerRow")))
+        List(KV(Option("treeType"), Option("treePerRow")),
+        KV(Option("treeType"), Option("nodeTreePerRow")))
       })
     )
     )


### PR DESCRIPTION
When querying the parameter document through the following statement, we found that some optional parameter values are missing in `values`.
```
load modelParams.SendMessage as output;
```

Reproduced as shown:
![middle_img_v2_ff21131f-a39b-4e5a-8819-d1e1d725734g](https://user-images.githubusercontent.com/20615623/140946655-c995ff94-198d-4c9b-a216-ccb589eb13a9.png)

I fixed the bug by modifying the parameter description.