### PR TITLE
Include ansj & nlp jars in release tar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ dev/docker/lib/
 streamingpro-cluster/dev/mlsql-cluster-docker/*.jar
 streamingpro-cluster/dev/mlsql-cluster-docker/*.tar.gz
 dev/sync-doc.sh
+dev/*.jar
 docs/gitbook/zh/_book/
 docs/gitbook/en/_book/
 contri/streamingpro-automl/logs/

--- a/dev/package.sh
+++ b/dev/package.sh
@@ -63,8 +63,9 @@ done
 
 if [[ ${ENABLE_CHINESE_ANALYZER} = true && ! -f $SELF/../dev/ansj_seg-5.1.6.jar  && ! -f $SELF/../dev/nlp-lang-1.7.8.jar ]]
 then
-  echo "When ENABLE_CHINESE_ANALYZER=true, ansj_seg-5.1.6.jar && nlp-lang-1.7.8.jar should be in ./dev/"
-  exit 1
+  echo "Downloading ansj & nlp jars"
+  wget --no-check-certificate https://mlsql-downloads.kyligence.io/nlp/nlp-lang-1.7.8.jar -P ${SELF}/../dev/
+  wget --no-check-certificate https://mlsql-downloads.kyligence.io/nlp/ansj_seg-5.1.6.jar -P ${SELF}/../dev/
 fi
 
 # before we compile and package, correct the version in MLSQLVersion
@@ -167,4 +168,3 @@ mvn clean ${COMMAND}  ${SKIPTEST} ${BASE_PROFILES}  ${TESTPROFILE}
 EOF
 mvn clean ${COMMAND}  ${SKIPTEST} ${BASE_PROFILES} ${TESTPROFILE}
 fi
-

--- a/streamingpro-assembly/src/main/assembly/assembly.xml
+++ b/streamingpro-assembly/src/main/assembly/assembly.xml
@@ -26,6 +26,17 @@
         </moduleSet>
     </moduleSets>
     <fileSets>
+        <!-- 3rd-party jars -->
+        <fileSet>
+            <!-- Executables -->
+            <directory>${project.parent.basedir}/dev</directory>
+            <includes>
+                <include>ansj_seg-5.1.6.jar</include>
+                <include>nlp-lang-1.7.8.jar</include>
+            </includes>
+            <outputDirectory>libs</outputDirectory>
+        </fileSet>
+
         <fileSet>
             <!-- Executables -->
             <directory>${project.parent.basedir}/dev</directory>


### PR DESCRIPTION
# What changes were proposed in this pull request?
- MLSQL algorithm TfIdfInPlace requires nlp related jars, so include them in the release tar ball

# How was this patch tested?
- Running make-distribution.sh and verified.

# Are there and DOC need to update?
- No doc change

# Spark Core Compatibility
Spark 2.x & 3.x