### PR TITLE
fix variable with session scope fails when visibility is not set

### DIFF
--- a/streamingpro-core/src/main/java/streaming/dsl/ScriptSQLExec.scala
+++ b/streamingpro-core/src/main/java/streaming/dsl/ScriptSQLExec.scala
@@ -221,7 +221,7 @@ class ScriptSQLExecListener(val _sparkSession: SparkSession, val _defaultPathPre
       case Some(items) =>
         items.collect().foreach { item =>
           addEnv(item.k, item.v)
-          addEnvVisibility(item.k, SetVisibilityParameter(item.v, getVisibility(item.config("visibility"))))
+          addEnvVisibility(item.k, SetVisibilityParameter(item.v, getVisibility(item.config.getOrElse("visibility","all"))))
         }
       case None =>
     }


### PR DESCRIPTION
# What changes were proposed in this pull request?

The following Kolo code will hit this bug:

```sql
include lib.`gitee.com/allwefantasy/lib-core`
where alias="libCore";

include local.`libCore.udf.hello`;
select hello() as name as output;
```

The root cause is that the include  statement will introduce a new variable with scope session, however which lack of 
visibility attribute:

```scala
// tech.mlsql.dsl.includes.LibIncludeSource line: 75 
envSession.set(s"__lib__${aliasValue}", finalProjectPath, Map(SetSession.__MLSQL_CL__ -> SetSession.SET_STATEMENT_CL))
```

When executing Kolo code every time, the engine will try to parse all these variables with scope session,  but it will fail since it extract attribute `visibility` without default value: 


```scala
//streaming.dsl.ScriptSQLExec  line: 224
addEnvVisibility(item.k, SetVisibilityParameter(item.v, getVisibility(item.config("visibility"))))
```

We fix this issue by set a default value:

```scala
//streaming.dsl.ScriptSQLExec  line: 224
addEnvVisibility(item.k, SetVisibilityParameter(item.v, getVisibility(item.config.getOrElse("visibility","all"))))
```

# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
