### PR TITLE
[DS] fix useCursorFetch option

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/core/datasource/impl/MLSQLJDBC.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/core/datasource/impl/MLSQLJDBC.scala
@@ -74,12 +74,12 @@ class MLSQLJDBC(override val uid: String) extends MLSQLSource with MLSQLSink wit
       MLSQLSparkConst.majorVersion(SparkCoreVersion.exactVersion) match {
         case 1 | 2 =>
           reader.options(Map("fetchsize" -> "1000"))
+          url = url.map(x => if (x.contains("useCursorFetch")) x else s"$x&useCursorFetch=true")
         case _ =>
           reader.options(Map("fetchsize" -> s"${Integer.MIN_VALUE}"))
       }
 
-      url = url.map(x => if (x.contains("useCursorFetch")) x else s"$x&useCursorFetch=true")
-        .map(x => if (x.contains("autoReconnect")) x else s"$x&autoReconnect=true")
+      url = url.map(x => if (x.contains("autoReconnect")) x else s"$x&autoReconnect=true")
         .map(x => if (x.contains("failOverReadOnly")) x else s"$x&failOverReadOnly=false")
     }
 

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLSendMessage.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLSendMessage.scala
@@ -671,7 +671,7 @@ class MailAgent() extends Logging with WowLog with DslTool {
       if (!smtpPort.equals("25") && !properties.containsKey("properties.mail.smtp.starttls.enable")
         && !properties.containsKey("properties.mail.smtp.ssl.enable")) {
         properties.setProperty("properties.mail.smtp.ssl.enable", smtpPort)
-        if (!properties.containsKey("properties.mail.smtp.starttls.enable")) {
+        if (!properties.containsKey("mail.smtp.socketFactory.class")) {
           properties.setProperty("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory")
         }
       }


### PR DESCRIPTION
## fix useCursorFetch option

useCursorFetch should be set when >0.
This can be done by setting the connection property useCursorFetch to true, and then calling setFetchSize(int) with int being the desired number of rows to be fetched each time:

```
conn = DriverManager.getConnection("jdbc:mysql://localhost/?useCursorFetch=true", "user", "s3cr3t");
stmt = conn.createStatement();
stmt.setFetchSize(100);
rs = stmt.executeQuery("SELECT * FROM your_table_here");
```