### PR TITLE
fix train/run/predict can only be capitalized

### DIFF
--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/TrainAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/TrainAdaptor.scala
@@ -89,7 +89,7 @@ class TrainAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdap
 
     options = options ++ Map("__LINE__" -> ctx.getStart.getLine.toString)
 
-    val firstKeywordInStatement = ctx.getChild(0).getText
+    val firstKeywordInStatement = ctx.getChild(0).getText.toLowerCase
 
     val isTrain = ETMethod.withName(firstKeywordInStatement) match {
       case ETMethod.PREDICT => false


### PR DESCRIPTION
# BUG PERFORMANCE

The capitalized train cannot be recognized by the program, resulting in an error

# ROOT CAUSE

The word obtained after word analytic is not converted to lowercase

# SOLUTION

toLowerCase

