### PR TITLE
CustomFS should not add spark.hadoop prefix to fs configs

### DIFF
--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/CustomFS.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/CustomFS.scala
@@ -44,11 +44,7 @@ class CustomFS(override val uid: String) extends MLSQLSource
     val session = config.df.get.sparkSession
     val (objectStoreConf,loadFileConf) = config.config.partition(item => item._1.startsWith("spark.hadoop") || item._1.startsWith("fs."))
 
-    objectStoreConf.map { item =>
-      if (item._1.startsWith("fs.")) {
-        ("spark.hadoop." + item._1, item._2)
-      } else item
-    }.foreach(item => session.conf.set(item._1, item._2))
+    objectStoreConf.foreach( item => session.conf.set(item._1, item._2) )
 
     val format = config.config.getOrElse("implClass", fullFormat)
     writer.options(loadFileConf).mode(config.mode).format(format).save(config.path)


### PR DESCRIPTION
# What changes were proposed in this pull request?
This is a follow-up to #PR-1636. Upload blob failed with exception:
```
org.apache.hadoop.fs.azure.AzureException: No credentials found for account ncovjepurheee2vry.blob.core.chinacloudapi.cn in the configuration, and its container ncov2019vjpn-storage is not accessible using anonymous credentials. Please check if the container exists first. If it is not publicly available, you have to provide account credentials.
org.apache.hadoop.fs.azure.AzureException: org.apache.hadoop.fs.azure.AzureException: No credentials found for account ncovjepurheee2vry.blob.core.chinacloudapi.cn in the configuration, and its container ncov2019vjpn-storage is not accessible using anonymous credentials. Please check if the container exists first. If it is not publicly available, you have to provide account credentials.
org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.createAzureStorageSession(AzureNativeFileSystemStore.java:1090)
org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.initialize(AzureNativeFileSystemStore.java:540)
org.apache.hadoop.fs.azure.NativeAzureFileSystem.initialize(NativeAzureFileSystem.java:1344)
org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3303)
org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:124)
org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3352)
org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3320)
org.apache.hadoop.fs.FileSystem.get(FileSystem.java:479)
org.apache.hadoop.fs.Path.getFileSystem(Path.java:361)
org.apache.spark.sql.execution.datasources.DataSource.planForWritingFileFormat(DataSource.scala:469)
org.apache.spark.sql.execution.datasources.DataSource.planForWriting(DataSource.scala:569)
org.apache.spark.sql.DataFrameWriter.saveToV1Source(DataFrameWriter.scala:438)
org.apache.spark.sql.DataFrameWriter.saveInternal(DataFrameWriter.scala:415)
org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:293)
tech.mlsql.datasource.impl.CustomFS.save(CustomFS.scala:55)
```

Investigation shows Azure client is not able to get account key from `Configuration` line 1936 of `org.apache.hadoop.conf.Configuration` . 
![getPassword-null](https://user-images.githubusercontent.com/12869649/147365700-340fac11-d8ad-492e-aec8-0084415bbe39.png)

Because CustomFS adds "spark.hadoop" prefix to  fs.* config; and fs.* config is passed to `Configuration` object as it is.
![SparkConf2hadoopConf](https://user-images.githubusercontent.com/12869649/147364979-8f65c17b-a54d-4681-8df8-253fd90be14b.png)

The `appendSparkHadoopConfigs` method in `SparkHadoopUtil.scala` is not called here.

```
private def appendSparkHadoopConfigs(conf: SparkConf, hadoopConf: Configuration): Unit = {
    // Copy any "spark.hadoop.foo=bar" spark properties into conf as "foo=bar"
    for ((key, value) <- conf.getAll if key.startsWith("spark.hadoop.")) {
      hadoopConf.set(key.substring("spark.hadoop.".length), value)
    }
    if (conf.getOption("spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version").isEmpty) {
      hadoopConf.set("mapreduce.fileoutputcommitter.algorithm.version", "1")
    }
  }
```
So, the solution would be removing "spark.hadoop" prefix.

# How was this patch tested?
## Test passed.
Test code
```sql
set rawData=''' 
{"jack":1,"jack2":2}
{"jack":2,"jack2":3}
''';
load jsonStr.`rawData` as table1;

SAVE overwrite table1 as FS.`wasb://<container_name>@<azure_account_name>.blob.core.chinacloudapi.cn/tmp/json_names_1` 
where `fs.azure.account.key.<azzure_account_name>.blob.core.chinacloudapi.cn`="<account_key>"
and `fs.AbstractFileSystem.wasb.impl`="org.apache.hadoop.fs.azure.Wasb"
and `fs.wasb.impl`="org.apache.hadoop.fs.azure.NativeAzureFileSystem"
and `fs.AbstractFileSystem.wasbs.impl`="org.apache.hadoop.fs.azure.Wasbs"
and `fs.wasbs.impl`="org.apache.hadoop.fs.azure.NativeAzureFileSystem"
and implClass="parquet"
and mode="overwrite";
```
Result:
```text
21/12/25 00:07:39  INFO log: Logging initialized @106158ms
21/12/25 00:07:39  WARN MetricsConfig: Cannot locate configuration: tried hadoop-metrics2-azure-file-system.properties,hadoop-metrics2.properties
21/12/25 00:07:39  INFO MetricsSystemImpl: Scheduled Metric snapshot period at 10 second(s).
21/12/25 00:07:39  INFO MetricsSystemImpl: azure-file-system metrics system started
21/12/25 00:07:47  WARN AzureFileSystemThreadPoolExecutor: Disabling threads for Delete operation as thread count 0 is <= 1
21/12/25 00:07:47  INFO AzureFileSystemThreadPoolExecutor: Time taken for Delete operation is: 240 ms with threads: 0
21/12/25 00:07:56  INFO CodecPool: Got brand-new compressor [.snappy]
21/12/25 00:07:57  INFO CodecPool: Got brand-new compressor [.snappy]
21/12/25 00:08:00  WARN AzureFileSystemThreadPoolExecutor: Disabling threads for Rename operation as thread count 0 is <= 1
21/12/25 00:08:00  WARN AzureFileSystemThreadPoolExecutor: Disabling threads for Rename operation as thread count 0 is <= 1
21/12/25 00:08:00  INFO AzureFileSystemThreadPoolExecutor: Time taken for Rename operation is: 219 ms with threads: 0
21/12/25 00:08:00  INFO AzureFileSystemThreadPoolExecutor: Time taken for Rename operation is: 235 ms with threads: 0
21/12/25 00:08:01  INFO FileOutputCommitter: Saved output of task 'attempt_202112250007501255028907373947739_0001_m_000000_3' to wasb://<container_name>@<account_name>.blob.core.chinacloudapi.cn/tmp/json_names_1/_temporary/0/task_202112250007501255028907373947739_0001_m_000000
21/12/25 00:08:01  INFO FileOutputCommitter: Saved output of task 'attempt_202112250007506806595567077198163_0001_m_000002_5' to wasb://<container_name>@<account_name>.blob.core.chinacloudapi.cn/tmp/json_names_1/_temporary/0/task_202112250007506806595567077198163_0001_m_000002
21/12/25 00:08:03  WARN AzureFileSystemThreadPoolExecutor: Disabling threads for Rename operation as thread count 0 is <= 1
21/12/25 00:08:04  INFO AzureFileSystemThreadPoolExecutor: Time taken for Rename operation is: 263 ms with threads: 0
21/12/25 00:08:04  INFO FileOutputCommitter: Saved output of task 'attempt_202112250007506759296783480954192_0001_m_000001_4' to wasb://<container_name>@<account_name>.blob.core.chinacloudapi.cn/tmp/json_names_1/_temporary/0/task_202112250007506759296783480954192_0001_m_000001
21/12/25 00:08:10  WARN AzureFileSystemThreadPoolExecutor: Disabling threads for Delete operation as thread count 0 is <= 1
```
# Are there and DOC need to update?
- [x] Doc is finished

# Spark Core Compatibility
