### PR TITLE
Change driver log server host

### DIFF
--- a/streamingpro-core/src/main/java/tech/mlsql/log/DriverLogServer.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/log/DriverLogServer.scala
@@ -71,8 +71,8 @@ class DriverLogServer(accessToken: String) extends BaseHttpLogServer with Loggin
         }
       }
     }
-    val uri = if (server.getURI.toString.last.equals('/')) server.getURI.toString.dropRight(1) else server.getURI.toString
-    (server, s"$uri$requestMapping", host, newPort)
+
+    (server, s"http://$host:$newPort/$requestMapping", host, newPort)
   }
 
   override def close(): Unit = {


### PR DESCRIPTION
The way to modify uri to IP:PORT.

`driver log server` uses fluent to get the server's URI, and if the host is configured separately, the VPN seems to interfere with this somehow. It will cause the domain name to not be properly mapped to the ip.
