### PR TITLE
add udf of crawler_http_with_header

### DIFF
--- a/streamingpro-core/pom.xml
+++ b/streamingpro-core/pom.xml
@@ -15,6 +15,7 @@
 <!--         <spark.version>2.4.3</spark.version> -->
 <!--         <spark.bigversion>2.4</spark.bigversion> -->
 <!--         <scalatest.version>3.0.3</scalatest.version> -->
+<!--        <scalatest.version>1.17.0</scalatest.version>-->
         <!-- spark 2.4 end -->
 
         <!-- spark 3.0 start -->
@@ -22,7 +23,8 @@
         <scala.binary.version>2.12</scala.binary.version> 
         <spark.version>3.1.1</spark.version> 
         <spark.bigversion>3.0</spark.bigversion> 
-        <scalatest.version>3.0.3</scalatest.version> 
+        <scalatest.version>3.0.8</scalatest.version>
+        <mockito-scala.version>1.17.0</mockito-scala.version>
         <!-- spark 3.0 end -->
     </properties>
     <artifactId>streamingpro-core-${spark.bigversion}_${scala.binary.version}</artifactId>
@@ -162,13 +164,43 @@
             </exclusions>
         </dependency>
 
+<!--        <dependency>-->
+<!--            <groupId>org.scalatest</groupId>-->
+<!--            <artifactId>scalatest_${scala.binary.version}</artifactId>-->
+<!--            <version>${scalatest.version}</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.scalatestplus</groupId>-->
+<!--            <artifactId>mockito-3-4_${scala.binary.version}</artifactId>-->
+<!--            <version>3.2.10.0</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.scalatestplus</groupId>-->
+<!--            <artifactId>junit-4-13_${scala.binary.version}</artifactId>-->
+<!--            <version>3.2.10.0</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
         <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>${scalatest.version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.8.0</version>
             <scope>test</scope>
         </dependency>
-       
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/streamingpro-core/src/main/java/tech/mlsql/crawler/HttpClientCrawler.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/crawler/HttpClientCrawler.scala
@@ -80,6 +80,7 @@ object HttpClientCrawler {
     }
   }
 
+
   def requestByMethod(url: String, method: String = "GET", params: Map[String, String], useProxy: Boolean = false): String = {
 
     var response: CloseableHttpResponse = null

--- a/streamingpro-core/src/test/scala/tech/mlsql/runtime/FunctionsTest.scala
+++ b/streamingpro-core/src/test/scala/tech/mlsql/runtime/FunctionsTest.scala
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.mlsql.runtime
+
+import org.apache.http.client.fluent.{Request, Response}
+import org.apache.http.entity.BasicHttpEntity
+import org.apache.http.message.{BasicHttpResponse, BasicStatusLine}
+import org.apache.http.{HttpResponse, ProtocolVersion}
+import org.apache.spark.sql.mlsql.session.MLSQLException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.mockito.ArgumentMatchers.{anyList, anyString}
+import org.mockito.Mockito.{mock, mockStatic, when}
+import org.mockito.{ArgumentMatchers, MockedStatic}
+import org.scalatest.FunSuite
+import streaming.dsl.ScriptSQLExec
+import tech.mlsql.crawler.udf.FunctionsUtils
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.Charset
+import scala.language.reflectiveCalls
+
+/**
+ * 22/01/2022 hellozepp(lisheng.zhanglin@163.com)
+ */
+
+class FunctionsTest extends FunSuite {
+
+  def initRest(reqStatic: MockedStatic[Request]): Unit = {
+    val reqMock = mock(classOf[Request])
+    val httpResp: HttpResponse = new BasicHttpResponse(new BasicStatusLine(
+      new ProtocolVersion("HTTP", 1, 1), 200, ""))
+    val entity = new BasicHttpEntity()
+    entity.setContent(new ByteArrayInputStream("{\"code\":\"200\",\"content\":\"ok\"}".getBytes()))
+    httpResp.setEntity(entity)
+    val responseMock = mock(classOf[Response])
+    when(responseMock.returnResponse()).thenReturn(httpResp)
+    // Get
+    reqStatic.when(() => Request.Get(anyString)).thenReturn(reqMock)
+    // Post json
+    reqStatic.when(() => Request.Post(anyString)).thenReturn(reqMock)
+    when(reqMock.bodyString(anyString, ArgumentMatchers.any())).thenReturn(reqMock)
+    // Post bodyForm
+    when(reqMock.bodyForm(anyList(), ArgumentMatchers.any())).thenReturn(reqMock)
+    ScriptSQLExec.contextGetOrForTest()
+    when(reqMock.execute()).thenReturn(responseMock)
+  }
+
+  test("http get") {
+    val reqStatic = mockStatic(classOf[Request])
+    tryWithResource(reqStatic) {
+      initRest(reqStatic)
+      reqStatic => {
+        val (status, content) = FunctionsUtils._http("http://www.byzer.org/home", "get",
+          params = Map("foo" -> "bar", "foo1" -> "bar"), headers = Map("Content-Type" -> "application/x-www-form-urlencoded"), Map())
+
+        println(s"status:$status, content:$content")
+        assertEquals(status, 200)
+        assertEquals(content, "{\"code\":\"200\",\"content\":\"ok\"}")
+        // verify url concat is legal.
+        reqStatic.verify(() => Request.Get("http://www.byzer.org/home?foo=bar&foo1=bar"))
+        // verify config set illegal of socket-timeout.
+        try {
+          FunctionsUtils._http("http://www.byzer.org/home", "get",
+            params = Map("foo" -> "bar", "foo1" -> "bar"), Map(), config = Map("socket-timeout" -> "a"))
+          throw new MLSQLException("The configuration is illegal, but no exception is displayed!")
+        } catch {
+          case e: Exception => println("success! e:" + e.getMessage)
+        }
+        // verify config set illegal of connect-timeout.
+        try {
+          FunctionsUtils._http("http://www.byzer.org/home", "get",
+            params = Map("foo" -> "bar", "foo1" -> "bar"), Map(), config = Map("connect-timeout" -> "a"))
+          throw new MLSQLException("The configuration is illegal, but no exception is displayed!")
+        } catch {
+          case e: Exception => println("success! e:" + e.getMessage)
+        }
+      }
+    }
+  }
+
+  test("http post with json body") {
+    val reqStatic = mockStatic(classOf[Request])
+    tryWithResource(reqStatic) {
+      initRest(reqStatic)
+      reqStatic => {
+        val (status, content) = FunctionsUtils._http("http://www.byzer.org/home", "post",
+          params = Map("body" -> "{\"a\":1,\"b\":2}"), headers = Map("Content-Type" -> "application/json"), Map())
+
+        println(s"status:$status, content:$content")
+        assertEquals(status, 200)
+        assertEquals(content, "{\"code\":\"200\",\"content\":\"ok\"}")
+        // verify url concat is legal.
+        reqStatic.verify(() => Request.Post("http://www.byzer.org/home"))
+
+        {
+          val (status, content) = FunctionsUtils._http("http://www.byzer.org/home", "post",
+            params = Map("foo" -> "bar", "foo1" -> "bar"), headers = Map("Content-Type" -> "application/x-www-form-urlencoded"), Map())
+          println(s"status:$status, content:$content")
+        }
+
+      }
+    }
+  }
+
+  def tryWithResource[A <: {def close(): Unit}, B](a: A)(f: A => B): B = {
+    try f(a)
+    finally {
+      if (a != null) a.close()
+    }
+  }
+
+}

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/MLSQLRest.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/MLSQLRest.scala
@@ -214,7 +214,7 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
         val finalUrl = if (paramsBuf.length > 0 && !skipParams) {
           val urlParam = paramsBuf.map { case (k, v) => s"${k}=${v}" }.mkString("&")
           if (url.contains("?")) {
-            url + "&" + urlParam
+            if (url.endsWith("?")) url + urlParam else url + "&" + urlParam
           } else {
             url + "?" + urlParam
           }
@@ -300,7 +300,7 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
         val finalUrl = if (paramsBuf.length > 0) {
           val urlParam = paramsBuf.map { case (k, v) => s"${k}=${v}" }.mkString("&")
           if (config.path.contains("?")) {
-            if (config.path.endsWith("?")) config.path + "&" + urlParam else config.path + urlParam
+            if (config.path.endsWith("?")) config.path + urlParam else config.path + "&" + urlParam
           } else {
             config.path + "?" + urlParam
           }

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/MLSQLRest.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/MLSQLRest.scala
@@ -300,7 +300,7 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
         val finalUrl = if (paramsBuf.length > 0) {
           val urlParam = paramsBuf.map { case (k, v) => s"${k}=${v}" }.mkString("&")
           if (config.path.contains("?")) {
-            config.path + urlParam
+            if (config.path.endsWith("?")) config.path + "&" + urlParam else config.path + urlParam
           } else {
             config.path + "?" + urlParam
           }


### PR DESCRIPTION
## How to use `crawler_http`

crawler_http(url, method, map("k1","v1","k2","v2")) - Request url, return response result

## parameter：

method - supported POST/GET
map - key/value  

## Example

```
SELECT crawler_http_with_header("https://www.csdn.com", "get", map(), map("Authorization", "Bearer ${app_access_token}")) AS h AS content;
```