### PR TITLE
Azure blob config does not require spark.hadoop prefix in CustomFS

### DIFF
--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/CustomFS.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/CustomFS.scala
@@ -24,6 +24,7 @@ class CustomFS(override val uid: String) extends MLSQLSource
     require(URI.create(config.path).getScheme!=null,"path should be with schema specified")
 
     val session = config.df.get.sparkSession
+    // Object store config starts with spark.hadoop or fs
     val (objectStoreConf,loadFileConf) = config.config.partition(item => item._1.startsWith("spark.hadoop") || item._1.startsWith("fs."))
 
     objectStoreConf.map { item =>
@@ -31,10 +32,14 @@ class CustomFS(override val uid: String) extends MLSQLSource
         ("spark.hadoop." + item._1, item._2)
       } else item
     }.foreach(item => session.conf.set(item._1, item._2))
+    // To load azure blob data, spark.hadoop prefix should be removed. Because NativeAzureFileSystem - azure blob's HDFS
+    // compatible API, looks up Azure blob credentials by fs.azure.account.key.<account>.blob.core.chinacloudapi.cn.
+    objectStoreConf.filter(_._1.startsWith("spark.hadoop.fs.azure")).foreach{ conf =>
+      session.conf.set( conf._1.replace("spark.hadoop.fs.azure", "fs.azure"), conf._2)
+    }
 
     val format = config.config.getOrElse("implClass", fullFormat)
     reader.options(loadFileConf).format(format).load(config.path)
-    
   }
 
   override def save(writer: DataFrameWriter[Row], config: DataSinkConfig): Any = {
@@ -49,6 +54,10 @@ class CustomFS(override val uid: String) extends MLSQLSource
         ("spark.hadoop." + item._1, item._2)
       } else item
     }.foreach(item => session.conf.set(item._1, item._2))
+    // See comments in load method
+    objectStoreConf.filter(_._1.startsWith("spark.hadoop.fs.azure")).foreach{ conf =>
+      session.conf.set( conf._1.replace("spark.hadoop.fs.azure", "fs.azure"), conf._2)
+    }
 
     val format = config.config.getOrElse("implClass", fullFormat)
     writer.options(loadFileConf).mode(config.mode).format(format).save(config.path)


### PR DESCRIPTION
# What changes were proposed in this pull request?
To load or save azure blob data, spark.hadoop prefix should be removed. Because NativeAzureFileSystem - azure blob's HDFS compatible API, looks up Azure blob credentials by fs.azure.account.key.${account}.blob.core.chinacloudapi.cn 

# How was this patch tested?
### Test script
```sql
set rawData='''
{"jack":1,"jack2":2}
{"jack":2,"jack2":3}
{"jack":3,"jack3":3}
{"Daniel":"D","jack3":3}
''';
load jsonStr.`rawData` as table1;

SAVE overwrite table1 as FS.`wasb://<blob_bucket>@<account>.blob.core.chinacloudapi.cn/tmp/json_names_1209` 
where `spark.hadoop.fs.azure.account.key.<account>.blob.core.chinacloudapi.cn`="<account_key>"
and `spark.hadoop.fs.AbstractFileSystem.wasb.impl`="org.apache.hadoop.fs.azure.Wasb"
and `spark.hadoop.fs.wasb.impl`="org.apache.hadoop.fs.azure.NativeAzureFileSystem"
and implClass="parquet";

load FS.`wasb://ncov2019vjpn-storage@ncovjepurheee2vry.blob.core.chinacloudapi.cn/tmp/json_names_1209` 
where `spark.hadoop.fs.azure.account.key.<account>.blob.core.chinacloudapi.cn`="<account_key>"
and `spark.hadoop.fs.AbstractFileSystem.wasb.impl`="org.apache.hadoop.fs.azure.Wasb"
and `spark.hadoop.fs.wasb.impl`="org.apache.hadoop.fs.azure.NativeAzureFileSystem"and implClass="parquet"
as table2;
```
Please note:
- All storage config should start with spark.hadoop
- Put jar `<groupId>tech.mlsql</groupId> <artifactId>azure-blob_2.7</artifactId> <version>1.0-SNAPSHOT</version>` in byzer-lang's classpath if you're using spark-2.4.3-bin-hadoop2.7.
- The script shows miminum configs to read or save data. 

Result: 
![image](https://user-images.githubusercontent.com/12869649/149907208-2e1b702c-8027-4cff-8811-d2a6f11f9ce5.png)

# Are there and DOC need to update?
- No doc changes

# Spark Core Compatibility
- Spark 3.1.1 & 2.4.3 test passed