### PR TITLE
Add rest page strategy.

### DIFF
--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/OffsetPageStrategy.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/OffsetPageStrategy.scala
@@ -1,0 +1,32 @@
+package tech.mlsql.datasource.helper.rest
+
+import org.apache.spark.sql.mlsql.session.MLSQLException
+import tech.mlsql.tool.Templates2
+
+class OffsetPageStrategy(params: Map[String, String]) extends PageStrategy {
+  val Array(_, pageParam) = params("config.page.values") match {
+    case s if s.contains(":") => s.split(":")
+    case _ => throw new MLSQLException("`config.page.values` should contains ':'")
+  }
+
+  val Array(initialPageNum, pageIncrement) = pageParam match {
+    case s if s.contains(",") => pageParam.split(",")
+    case _ => Array(pageParam, "1")
+  }
+
+  var pageNum: Int = initialPageNum.trim.toInt
+  val pageAddend: Int = pageIncrement.trim.toInt
+
+  override def pageValues(_content: Option[Any]) = Array[String](pageNum.toString)
+
+
+  override def nexPage: OffsetPageStrategy = {
+    pageNum += pageAddend
+    this
+  }
+
+  override def pageUrl(_content: Option[Any]): String = {
+    val urlTemplate = params("config.page.next")
+    Templates2.evaluate(urlTemplate, pageValues(None))
+  }
+}

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/PageStrategyDispatcher.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/PageStrategyDispatcher.scala
@@ -8,6 +8,8 @@ object PageStrategyDispatcher {
     params("config.page.values").trim.toLowerCase match {
       case s if s.startsWith("auto-increment") =>
         new AutoIncrementPageStrategy(params)
+      case s if s.startsWith("offset") =>
+        new OffsetPageStrategy(params)
       case _ => new DefaultPageStrategy(params)
     }
   }


### PR DESCRIPTION
# background
使用rest数据源时我遇到这样一种情况：请求体中可以设置 startAt 以及 size ，每次最多只能获取100条数据，返回结果中没有下次请求的链接或者offset。
按照现在的使用方法，设置 autoincrement 时，只能每次增加 1
而我需要每次增加100，扩展一下需要这个加数是一个变量
我需要更改一下 rest 的使用方式：
```
-- 原来
load Rest.`$url` 
where `config.method`="get"
and `config.page.values` = "auto-increment:100"
and `config.page.next` = "https://api.123.com/rest/api/search?startAt={0}"
and `config.page.limit` = "10"
as sr_1;
-- 现在
load Rest.`$url` 
where `config.method`="get"
and `config.page.values` = "auto-increment:100,100" -- Here is the point
and `config.page.next` = "https://api.123.com/rest/api/search?startAt={0}"
and `config.page.limit` = "10"
as sr_1;
```
# update
更新了 AutoIncrementPageStrategy 类的变量获取以及 nexPage 方法。

# test
tested
要求用户的每页 size 和 increment 必须匹配，否则会出现重复的请求结果
