### PR TITLE
Solved in the console, when the page is empty, use the key combinatio…

### DIFF
--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/AutoSuggestContext.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/AutoSuggestContext.scala
@@ -165,7 +165,7 @@ class AutoSuggestContext(val session: SparkSession,
    * We need to convert it to the relative pos in every statement
    */
   private[autosuggest] def _suggest(tokenPos: TokenPos): List[SuggestItem] = {
-    assert(_rawColumnNum != 0 || _rawColumnNum != 0, "lineNum and columnNum should be set")
+    assert(_rawColumnNum != 0 || _rawLineNum != 0, "lineNum and columnNum should be set")
     if (isInDebugMode) {
       logInfo("Global Pos::" + tokenPos.str + s"::${rawTokens(tokenPos.pos)}")
     }


### PR DESCRIPTION
…n option+space (mac) or control+space (Windows), an NPE error will occur.
#1685
Fixed the error of assert in AutoSuggestContext.scala

# What changes were proposed in this pull request?
- [ ] Finshed changes describe
Solve the problem that NPE will occur in the console, when the page is empty, use the key combination option+space (mac) or control+space (Windows)。
# How was this patch tested?
- [ ] Testing done
<img width="1331" alt="截屏2022-02-20 下午10 53 25" src="https://user-images.githubusercontent.com/70516188/154849505-76d0f7cb-2362-46cb-9ad5-c29a69cf2a4d.png">

# Are there and DOC need to update?
- [ ] Doc is finished
Do not need to update DOC
# Spark Core Compatibility
