### PR TITLE
Set up http socketTimeout and connectionTime in RestUtils

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestUtils.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestUtils.scala
@@ -17,6 +17,11 @@ object RestUtils {
        .map{ case (name, value) => new BasicNameValuePair(name, value) }.toSeq
 
     Request.Post(urlString)
+      // Socket timeout is in milliseconds, default to 20 minutes
+      // TODO this should be configurable
+      .socketTimeout(20 * 60 * 1000 )
+      // Timeout to obtain Socket connection
+      .connectTimeout(10 * 1000)
       .addHeader("Content-Type", "application/x-www-form-urlencoded")
       .body(new UrlEncodedFormEntity(nameValuePairs.asJava, DefaultHttpTransportService.charset))
       .execute()


### PR DESCRIPTION
# What changes were proposed in this pull request?
- Increase default socketTimeOut to 20 minutes connectionTimeOut 10 seconds in RestUtils


# How was this patch tested?
- Passed test in Kyligence internal env.

# Are there and DOC need to update?
- No doc changes

# Spark Core Compatibility
Compatible with Spark 2.4 & 3.1 