### PR TITLE
Add hasNextPage to Rest Datasource Paging Strategy 

### DIFF
--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/AutoSuggestContext.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/AutoSuggestContext.scala
@@ -165,7 +165,7 @@ class AutoSuggestContext(val session: SparkSession,
    * We need to convert it to the relative pos in every statement
    */
   private[autosuggest] def _suggest(tokenPos: TokenPos): List[SuggestItem] = {
-    assert(_rawColumnNum != 0 || _rawColumnNum != 0, "lineNum and columnNum should be set")
+    assert(_rawColumnNum != 0 || _rawLineNum != 0, "lineNum and columnNum should be set")
     if (isInDebugMode) {
       logInfo("Global Pos::" + tokenPos.str + s"::${rawTokens(tokenPos.pos)}")
     }

--- a/streamingpro-mlsql/pom.xml
+++ b/streamingpro-mlsql/pom.xml
@@ -10,24 +10,24 @@
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <!-- spark 2.4 start -->
-<!--         <scala.version>2.11.12</scala.version> -->
-<!--         <scala.binary.version>2.11</scala.binary.version> -->
-<!--         <spark.version>2.4.3</spark.version> -->
-<!--         <spark.bigversion>2.4</spark.bigversion> -->
-<!--         <scalatest.version>3.0.3</scalatest.version> -->
+        <!--         <scala.version>2.11.12</scala.version> -->
+        <!--         <scala.binary.version>2.11</scala.binary.version> -->
+        <!--         <spark.version>2.4.3</spark.version> -->
+        <!--         <spark.bigversion>2.4</spark.bigversion> -->
+        <!--         <scalatest.version>3.0.3</scalatest.version> -->
         <!-- spark 2.4 end -->
 
         <!-- spark 3.0 start -->
-        <scala.version>2.12.10</scala.version> 
-        <scala.binary.version>2.12</scala.binary.version> 
-        <spark.version>3.1.1</spark.version> 
-        <spark.bigversion>3.0</spark.bigversion> 
-        <scalatest.version>3.0.3</scalatest.version> 
+        <scala.version>2.12.10</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.version>3.1.1</spark.version>
+        <spark.bigversion>3.0</spark.bigversion>
+        <scalatest.version>3.0.3</scalatest.version>
         <!-- spark 3.0 end -->
     </properties>
     <artifactId>streamingpro-mlsql-spark_${spark.bigversion}_${scala.binary.version}</artifactId>
     <profiles>
-        
+
         <profile>
             <id>aliyun-oss</id>
             <properties>
@@ -42,7 +42,7 @@
 
             </dependencies>
         </profile>
-        
+
         <profile>
             <id>shade</id>
             <build>
@@ -298,7 +298,7 @@
                     <artifactId>mlsql-healthy-${spark.bigversion}_${scala.binary.version}</artifactId>
                     <version>${project.parent.version}</version>
                 </dependency>
-                
+
                 <dependency>
                     <groupId>org.apache.spark</groupId>
                     <artifactId>spark-streaming-kafka-0-8_${scala.binary.version}</artifactId>
@@ -331,9 +331,9 @@
         <profile>
             <id>streamingpro-spark-3.0.0-adaptor</id>
 
-                <activation>
-                    <activeByDefault>true</activeByDefault>
-                </activation>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <dependencies>
 
                 <dependency>
@@ -481,7 +481,7 @@
             <version>${kylin-jdbc.version}</version>
         </dependency>
 
-        
+
         <dependency>
             <groupId>tech.mlsql</groupId>
             <artifactId>common-utils_${scala.binary.version}</artifactId>
@@ -547,18 +547,6 @@
             <version>${project.parent.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.scalactic</groupId>
-            <artifactId>scalactic_${scala.binary.version}</artifactId>
-            <version>3.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.0.0</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -718,6 +706,32 @@
                     <artifactId>netty</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>${scalatest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
         </dependency>
 
 

--- a/streamingpro-mlsql/src/main/java/org/apache/spark/streaming/SparkOperationUtil.scala
+++ b/streamingpro-mlsql/src/main/java/org/apache/spark/streaming/SparkOperationUtil.scala
@@ -241,4 +241,11 @@ trait SparkOperationUtil {
       }
     }
   }
+
+  def tryWithResource[A <: {def close(): Unit}, B](a: A)(f: A => B): B = {
+    try f(a)
+    finally {
+      if (a != null) a.close()
+    }
+  }
 }

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/AutoIncrementPageStrategy.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/AutoIncrementPageStrategy.scala
@@ -6,20 +6,29 @@ import tech.mlsql.tool.Templates2
  * 3/12/2021 WilliamZhu(allwefantasy@gmail.com)
  */
 class AutoIncrementPageStrategy(params: Map[String, String]) extends PageStrategy {
-  val Array(_, initialPageNum) = params("config.page.values").split(":")
+  // config.page.values="auto-increment:0"
+  // config.page.stop="sizeZero:$.content"
+  val Array(_, initialPageNum) = {
+    if (!params.contains(PageStrategy.PAGE_CONFIG_VALUES)) {
+      Array("", "0")
+    } else {
+      params("config.page.values").split(":")
+    }
+
+  }
   var pageNum = initialPageNum.toInt
 
-  override def pageValues(_content: Option[Any]) = Array[String](pageNum.toString)
-
-
-  override def nexPage: AutoIncrementPageStrategy = {
+  override def nexPage(_content: Option[Any]): AutoIncrementPageStrategy = {
     pageNum += 1
     this
   }
 
   override def pageUrl(_content: Option[Any]): String = {
     val urlTemplate = params("config.page.next")
-    Templates2.evaluate(urlTemplate, pageValues(None))
+    Templates2.evaluate(urlTemplate, Array(pageNum.toString))
   }
 
+  override def hasNextPage(_content: Option[Any]): Boolean = {
+    PageStrategy.defaultHasNextPage(params, _content)
+  }
 }

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/DefaultPageStrategy.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/DefaultPageStrategy.scala
@@ -8,7 +8,7 @@ import tech.mlsql.tool.Templates2
  */
 class DefaultPageStrategy(params: Map[String, String]) extends PageStrategy {
 
-  override def pageValues(_content: Option[Any]): Array[String] = {
+  def pageValues(_content: Option[Any]): Array[String] = {
     try {
       val content = _content.get.toString
       params("config.page.values").split(",").map(path => JsonPath.read[String](content, path)).toArray
@@ -20,12 +20,17 @@ class DefaultPageStrategy(params: Map[String, String]) extends PageStrategy {
     }
   }
 
-  override def nexPage: DefaultPageStrategy = {
+  override def nexPage(_content: Option[Any]): DefaultPageStrategy = {
     this
   }
 
   override def pageUrl(_content: Option[Any]): String = {
     val urlTemplate = params("config.page.next")
     Templates2.evaluate(urlTemplate, pageValues(_content))
+  }
+
+  override def hasNextPage(_content: Option[Any]): Boolean = {
+    val pageValues = this.pageValues(_content)
+    pageValues.size == 0 || pageValues.filter(value => value == null || value.isEmpty).size > 0
   }
 }

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/DefaultPageStrategy.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/DefaultPageStrategy.scala
@@ -11,7 +11,7 @@ class DefaultPageStrategy(params: Map[String, String]) extends PageStrategy {
   def pageValues(_content: Option[Any]): Array[String] = {
     try {
       val content = _content.get.toString
-      params("config.page.values").split(",").map(path => JsonPath.read[String](content, path)).toArray
+      params("config.page.values").split(",").map(path => JsonPath.read[Object](content, path).toString).toArray
     } catch {
       case _: com.jayway.jsonpath.PathNotFoundException =>
         Array[String]()
@@ -30,7 +30,12 @@ class DefaultPageStrategy(params: Map[String, String]) extends PageStrategy {
   }
 
   override def hasNextPage(_content: Option[Any]): Boolean = {
-    val pageValues = this.pageValues(_content)
-    pageValues.size == 0 || pageValues.filter(value => value == null || value.isEmpty).size > 0
+    if (params.get("config.page.stop").isDefined) {
+      PageStrategy.defaultHasNextPage(params, _content)
+    } else {
+      val pageValues = this.pageValues(_content)
+      !(pageValues.size == 0 || pageValues.filter(value => value == null || value.isEmpty).size > 0)
+    }
+
   }
 }

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/OffsetPageStrategy.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/OffsetPageStrategy.scala
@@ -17,16 +17,17 @@ class OffsetPageStrategy(params: Map[String, String]) extends PageStrategy {
   var pageNum: Int = initialPageNum.trim.toInt
   val pageAddend: Int = pageIncrement.trim.toInt
 
-  override def pageValues(_content: Option[Any]) = Array[String](pageNum.toString)
-
-
-  override def nexPage: OffsetPageStrategy = {
+  override def nexPage(_content: Option[Any]): OffsetPageStrategy = {
     pageNum += pageAddend
     this
   }
 
   override def pageUrl(_content: Option[Any]): String = {
     val urlTemplate = params("config.page.next")
-    Templates2.evaluate(urlTemplate, pageValues(None))
+    Templates2.evaluate(urlTemplate, Array(pageNum.toString))
+  }
+
+  override def hasNextPage(_content: Option[Any]): Boolean = {
+    PageStrategy.defaultHasNextPage(params, _content)
   }
 }

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/PageStrategy.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/PageStrategy.scala
@@ -1,12 +1,62 @@
 package tech.mlsql.datasource.helper.rest
 
+import com.jayway.jsonpath.JsonPath
+import net.sf.json.JSONArray
+import org.apache.spark.sql.mlsql.session.MLSQLException
+
 /**
  * 3/12/2021 WilliamZhu(allwefantasy@gmail.com)
  */
 trait PageStrategy {
-  def pageValues(_content: Option[Any]): Array[String]
 
-  def nexPage: PageStrategy
+  def nexPage(_content: Option[Any]): PageStrategy
+
+  def hasNextPage(_content: Option[Any]): Boolean
 
   def pageUrl(_content: Option[Any]): String
+}
+
+object PageStrategy {
+  val PAGE_CONFIG_VALUES = "config.page.values"
+
+  def defaultHasNextPage(params: Map[String, String], _content: Option[Any]): Boolean = {
+    val stopPagingCondition = params.get("config.page.stop")
+
+    if (stopPagingCondition.isEmpty) {
+      //todo: Choose a better default value
+      return true
+    }
+    val content = _content.get.toString
+    val Array(func, jsonPath) = stopPagingCondition.get.split(":")
+
+    func match {
+      case "sizeZero" =>
+        try {
+          val targetValue = JsonPath.read[net.minidev.json.JSONArray](content, jsonPath)
+          targetValue.size() > 0
+        } catch {
+          case _: com.jayway.jsonpath.PathNotFoundException =>
+            false
+        }
+
+      case "notExists" => try {
+        JsonPath.read[String](content, jsonPath)
+        true
+      } catch {
+        case _: com.jayway.jsonpath.PathNotFoundException =>
+          false
+      }
+      case "equals" =>
+        try {
+          val Array(realJsonPath, equalValue) = jsonPath.split(",")
+          val targetValue = JsonPath.read[String](content, realJsonPath)
+          targetValue != equalValue
+        } catch {
+          case _: com.jayway.jsonpath.PathNotFoundException =>
+            true
+        }
+
+      case _ => throw new MLSQLException(s"config.page.stop with ${func} is not supported")
+    }
+  }
 }

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/PageStrategy.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/PageStrategy.scala
@@ -1,7 +1,6 @@
 package tech.mlsql.datasource.helper.rest
 
 import com.jayway.jsonpath.JsonPath
-import net.sf.json.JSONArray
 import org.apache.spark.sql.mlsql.session.MLSQLException
 
 /**
@@ -30,7 +29,7 @@ object PageStrategy {
     val Array(func, jsonPath) = stopPagingCondition.get.split(":")
 
     func match {
-      case "sizeZero" =>
+      case "size-zero" | "sizeZero" =>
         try {
           val targetValue = JsonPath.read[net.minidev.json.JSONArray](content, jsonPath)
           targetValue.size() > 0
@@ -39,8 +38,8 @@ object PageStrategy {
             false
         }
 
-      case "notExists" => try {
-        JsonPath.read[String](content, jsonPath)
+      case "not-exists" | "notExists" => try {
+        JsonPath.read[Object](content, jsonPath)
         true
       } catch {
         case _: com.jayway.jsonpath.PathNotFoundException =>
@@ -49,7 +48,7 @@ object PageStrategy {
       case "equals" =>
         try {
           val Array(realJsonPath, equalValue) = jsonPath.split(",")
-          val targetValue = JsonPath.read[String](content, realJsonPath)
+          val targetValue = JsonPath.read[Object](content, realJsonPath).toString
           targetValue != equalValue
         } catch {
           case _: com.jayway.jsonpath.PathNotFoundException =>

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/PageStrategyDispatcher.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/PageStrategyDispatcher.scala
@@ -6,7 +6,7 @@ package tech.mlsql.datasource.helper.rest
 object PageStrategyDispatcher {
   def get(params: Map[String, String]): PageStrategy = {
     params("config.page.values").trim.toLowerCase match {
-      case s if s.startsWith("auto-increment") =>
+      case s if s.startsWith("auto-increment") || s.startsWith("autoIncrement") =>
         new AutoIncrementPageStrategy(params)
       case s if s.startsWith("offset") =>
         new OffsetPageStrategy(params)

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/MLSQLRest.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/MLSQLRest.scala
@@ -1,10 +1,5 @@
 package tech.mlsql.datasource.impl
 
-import java.net.URLEncoder
-import java.nio.charset.Charset
-import java.util.UUID
-
-import com.jayway.jsonpath.JsonPath
 import org.apache.http.client.fluent.{Form, Request}
 import org.apache.http.entity.ContentType
 import org.apache.http.entity.mime.{HttpMultipartMode, MultipartEntityBuilder}
@@ -16,6 +11,7 @@ import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, S
 import streaming.core.datasource._
 import streaming.dsl.ScriptSQLExec
 import streaming.dsl.mmlib.algs.param.{BaseParams, WowParams}
+import streaming.log.WowLog
 import streaming.rest.RestUtils
 import tech.mlsql.common.form._
 import tech.mlsql.common.utils.distribute.socket.server.JavaUtils
@@ -25,13 +21,16 @@ import tech.mlsql.datasource.helper.rest.PageStrategyDispatcher
 import tech.mlsql.dsl.adaptor.DslTool
 import tech.mlsql.tool.{HDFSOperatorV2, Templates2}
 
+import java.net.URLEncoder
+import java.nio.charset.Charset
+import java.util.UUID
 import scala.collection.mutable.ArrayBuffer
 
 class MLSQLRest(override val uid: String) extends MLSQLSource
   with MLSQLSink
   with MLSQLSourceInfo
   with MLSQLSourceConfig
-  with MLSQLRegistry with DslTool with WowParams with Logging {
+  with MLSQLRegistry with DslTool with WowParams with Logging with WowLog {
 
 
   def this() = this(BaseParams.randomUID())
@@ -45,7 +44,7 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
    * and `header.content-type`="application/json"
    *
    * and `config.page.next`="http://mlsql.tech/api?cursor={0}&wow={1}"
-   * and `config.page.skip-params`="true" 
+   * and `config.page.skip-params`="true"
    * and `config.page.values`="$.path,$.path2" -- json path
    * and `config.page.interval`="10ms"
    * and `config.page.retry`="3"
@@ -70,10 +69,12 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
    * run jsonTable AS JsonExpandExt.`` WHERE inputCol="jsonColumn" AS table_3;
    *
    * select * from table_3 as output;
-   **/
+   * */
   override def load(reader: DataFrameReader, config: DataSourceConfig): DataFrame = {
     val skipParams = config.config.getOrElse("config.page.skip-params", "false").toBoolean
     val retryInterval = JavaUtils.timeStringAsMs(config.config.getOrElse("config.retry.interval", "1s"))
+
+    val debug = config.config.getOrElse("config.debug", "false").toBoolean
 
     (config.config.get("config.page.next"), config.config.get("config.page.values")) match {
       case (Some(urlTemplate), Some(jsonPath)) =>
@@ -83,8 +84,10 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
         var count = 1
 
         val pageStrategy = PageStrategyDispatcher.get(config.config)
-
-
+        if (debug) {
+          logInfo(format(s"Started to get Page ${count} ${config.path} "))
+        }
+        val firstPageFetchTime = System.currentTimeMillis()
         val (_, firstDfOpt) = RestUtils.executeWithRetrying[(Int, Option[DataFrame])](maxTries)((() => {
           try {
             val tempDF = _http(config.path, config.config, false, config.df.get.sparkSession)
@@ -114,26 +117,38 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
 
         val uuid = UUID.randomUUID().toString.replaceAll("-", "")
         val context = ScriptSQLExec.context()
-        val tmpTablePath = resourceRealPath(context.execListener, Option(context.owner), PathFun("__tmp__").add(uuid).toPath)
+        val tmpTablePath = resourceRealPath(context.execListener, Option(context.owner),
+          PathFun("__tmp__").add("rest").add(uuid).toPath)
         context.execListener.addEnv(classOf[MLSQLRest].getName, tmpTablePath)
         firstDf.write.format("parquet").mode(SaveMode.Append).save(tmpTablePath)
+
+        if (debug) {
+          logInfo(format(s"End to get Page ${count} ${config.path} Consume:${System.currentTimeMillis() - firstPageFetchTime}ms"))
+        }
 
         while (count < maxSize) {
           Thread.sleep(pageInterval)
           count += 1
+
           val row = firstDf.select(F.col("content").cast(StringType), F.col("status")).head
           val content = row.getString(0)
+          val status = row.getInt(1)
+          val hasNextPage = pageStrategy.hasNextPage(Option(content))
 
-          val pageValues = pageStrategy.pageValues(Option(content))
-
-
-          val shouldStop = pageValues.size == 0 || pageValues.filter(value => value == null || value.isEmpty).size > 0
-          if (shouldStop) {
+          if (status != 200 || !hasNextPage) {
+            if (debug) {
+              logInfo(s"Stop paging. The last Page ${count - 1} ${config.path} status: ${status} hasNextPage: ${hasNextPage} ")
+            }
             count = maxSize
           } else {
             val newUrl = pageStrategy.pageUrl(Option(content))
+            val tempTime = System.currentTimeMillis()
             RestUtils.executeWithRetrying[(Int, Option[DataFrame])](maxTries)((() => {
               try {
+                if (debug) {
+                  logInfo(format(s"Started get Page ${count} ${newUrl}"))
+                }
+
                 val tempDF = _http(newUrl, config.config, skipParams, config.df.get.sparkSession)
                 val row = tempDF.select(F.col("content").cast(StringType), F.col("status")).head
                 firstDf = tempDF
@@ -153,8 +168,17 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
               },
               failResp => logInfo(s"Fail request ${newUrl} failed after ${maxTries} attempts. the last response status is: ${failResp._1}. ")
             )
-            firstDf.write.format("parquet").mode(SaveMode.Append).save(tmpTablePath)
-            pageStrategy.nexPage
+
+            val row = firstDf.select(F.col("content").cast(StringType), F.col("status")).head
+            val status = row.getInt(1)
+            //page should be 200 otherwise should not save in parquet file
+            if (status == 200) {
+              firstDf.write.format("parquet").mode(SaveMode.Append).save(tmpTablePath)
+            }
+            pageStrategy.nexPage(Option(content))
+            if (debug) {
+              logInfo(format(s"End to get Page ${count} ${newUrl} Consume: ${System.currentTimeMillis() - tempTime}"))
+            }
           }
 
         }

--- a/streamingpro-mlsql/src/test/scala/tech/mlsql/test/ds/MLSQLRestTest.scala
+++ b/streamingpro-mlsql/src/test/scala/tech/mlsql/test/ds/MLSQLRestTest.scala
@@ -80,7 +80,7 @@ class MLSQLRestTest extends FunSuite with SparkOperationUtil with BasicMLSQLConf
               "config.page.values" -> "auto-increment:0",
               "config.page.stop" -> "equals:$.content,fail",
               "config.page.limit" -> "4",
-              "config.debug" -> "true",
+              "config.debug" -> "true"
             ), Option(session.emptyDataFrame)
           ))
           assertEquals(3, res.collect().length, "Page three times should have three rows")
@@ -121,7 +121,7 @@ class MLSQLRestTest extends FunSuite with SparkOperationUtil with BasicMLSQLConf
               "config.page.values" -> "offset:0,1",
               "config.page.stop" -> "equals:$.content,fail",
               "config.page.limit" -> "4",
-              "config.debug" -> "true",
+              "config.debug" -> "true"
             ), Option(session.emptyDataFrame)
           ))
           val rows = res.collect()
@@ -169,7 +169,7 @@ class MLSQLRestTest extends FunSuite with SparkOperationUtil with BasicMLSQLConf
               "config.page.values" -> "auto-increment:0",
               "config.page.stop" -> "sizeZero:$.content",
               "config.page.limit" -> "4",
-              "config.debug" -> "true",
+              "config.debug" -> "true"
             ), Option(session.emptyDataFrame)
           ))
           val rows = res.collect()

--- a/streamingpro-mlsql/src/test/scala/tech/mlsql/test/ds/MLSQLRestTest.scala
+++ b/streamingpro-mlsql/src/test/scala/tech/mlsql/test/ds/MLSQLRestTest.scala
@@ -1,0 +1,185 @@
+package tech.mlsql.test.ds
+
+import org.apache.http.client.fluent.{Request, Response}
+import org.apache.http.entity.BasicHttpEntity
+import org.apache.http.message.{BasicHttpResponse, BasicStatusLine}
+import org.apache.http.{HttpResponse, ProtocolVersion}
+import org.apache.spark.streaming.SparkOperationUtil
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.mockito.ArgumentMatchers.{anyList, anyString}
+import org.mockito.Mockito.{mock, mockStatic, when}
+import org.mockito.{ArgumentMatchers, MockedStatic}
+import org.scalatest.FunSuite
+import streaming.core.BasicMLSQLConfig
+import streaming.core.datasource.DataSourceConfig
+import streaming.core.strategy.platform.SparkRuntime
+import streaming.dsl.ScriptSQLExec
+import tech.mlsql.common.utils.log.Logging
+import tech.mlsql.datasource.impl.MLSQLRest
+
+import java.io.ByteArrayInputStream
+
+/**
+ * 26/2/2022 WilliamZhu(allwefantasy@gmail.com)
+ */
+class MLSQLRestTest extends FunSuite with SparkOperationUtil with BasicMLSQLConfig with Logging {
+
+  def buildResp(str: String, status: Int = 200) = {
+    val httpResp: HttpResponse = new BasicHttpResponse(new BasicStatusLine(
+      new ProtocolVersion("HTTP", 1, 1), status, ""))
+    val entity = new BasicHttpEntity()
+    entity.setContent(new ByteArrayInputStream(str.getBytes))
+    httpResp.setEntity(entity)
+    httpResp
+  }
+
+  def mockStaticRequest = {
+    val reqStatic = mockStatic(classOf[Request])
+    val reqMock = mock(classOf[Request])
+    // Get
+    reqStatic.when(new MockedStatic.Verification() {
+      override def apply(): Unit = {
+        Request.Get(anyString)
+      }
+    }).thenReturn(reqMock)
+    // Post json
+    reqStatic.when(new MockedStatic.Verification() {
+      override def apply(): Unit = {
+        Request.Post(anyString)
+      }
+    }).thenReturn(reqMock)
+
+    when(reqMock.bodyString(anyString, ArgumentMatchers.any())).thenReturn(reqMock)
+    when(reqMock.bodyForm(anyList(), ArgumentMatchers.any())).thenReturn(reqMock)
+    (reqStatic, reqMock)
+  }
+
+  test("auto-increment page strategy stop with equals") {
+
+    withBatchContext(setupBatchContext(batchParams, null)) { runtime: SparkRuntime =>
+      val (reqStatic, reqMock) = mockStaticRequest
+      val responseMock = mock(classOf[Response])
+      tryWithResource(reqStatic) {
+
+        when(responseMock.returnResponse()).
+          thenReturn(buildResp(
+            """
+              |{"code":"200","content":"ok"}
+              |""".stripMargin)).
+          thenReturn(buildResp("{\"code\":\"200\",\"content\":\"ok\"}")).
+          thenReturn(buildResp("{\"code\":\"200\",\"content\":\"fail\"}"))
+
+        when(reqMock.execute()).thenReturn(responseMock)
+        reqStatic => {
+          autoGenerateContext(runtime)
+          val rest = new MLSQLRest()
+          val session = ScriptSQLExec.context().execListener.sparkSession
+          val res = rest.load(session.read, DataSourceConfig(
+            "http://www.byzer.org/list", Map(
+              "config.page.next" -> "http://www.byzer.org/list?{0}",
+              "config.page.values" -> "auto-increment:0",
+              "config.page.stop" -> "equals:$.content,fail",
+              "config.page.limit" -> "4",
+              "config.debug" -> "true",
+            ), Option(session.emptyDataFrame)
+          ))
+          assertEquals(3, res.collect().length, "Page three times should have three rows")
+        }
+      }
+
+    }
+
+  }
+
+
+  test("offset page strategy stop with wrong status") {
+
+    withBatchContext(setupBatchContext(batchParams, null)) { runtime: SparkRuntime =>
+      val (reqStatic, reqMock) = mockStaticRequest
+      val responseMock = mock(classOf[Response])
+      tryWithResource(reqStatic) {
+
+        when(responseMock.returnResponse()).
+          thenReturn(buildResp(
+            """
+              |{"code":"200","content":"ok"}
+              |""".stripMargin)).
+          thenReturn(buildResp("{\"code\":\"200\",\"content\":\"ok\"}", 400)).
+          thenReturn(buildResp("{\"code\":\"200\",\"content\":\"fail\"}"))
+
+        when(reqMock.execute()).thenReturn(responseMock)
+        reqStatic => {
+          autoGenerateContext(runtime)
+          val rest = new MLSQLRest()
+          val session = ScriptSQLExec.context().execListener.sparkSession
+          val res = rest.load(session.read, DataSourceConfig(
+            "http://www.byzer.org/list", Map(
+              // set the retry to 1 means no retry. If this value is not 1, then the
+              // retry mechanism will consume the mock response
+              "config.page.retry" -> "1",
+              "config.page.next" -> "http://www.byzer.org/list?{0}",
+              "config.page.values" -> "offset:0,1",
+              "config.page.stop" -> "equals:$.content,fail",
+              "config.page.limit" -> "4",
+              "config.debug" -> "true",
+            ), Option(session.emptyDataFrame)
+          ))
+          val rows = res.collect()
+          // here why there are two
+          assertEquals(1, rows.length)
+          assertEquals(rows.head.getInt(1), 200)
+        }
+      }
+    }
+  }
+
+  test("auto-increment page strategy stop with sizeZero") {
+
+    withBatchContext(setupBatchContext(batchParams, null)) { runtime: SparkRuntime =>
+      val (reqStatic, reqMock) = mockStaticRequest
+      val responseMock = mock(classOf[Response])
+      tryWithResource(reqStatic) {
+
+        when(responseMock.returnResponse()).
+          thenReturn(buildResp(
+            """
+              |{"code":"200","content":[{"title":"wow"}]}
+              |""".stripMargin)).
+          thenReturn(buildResp(
+            """
+              |{"code":"200","content":[{"title":"wow"}]}
+              |""".stripMargin)).
+          thenReturn(buildResp(
+            """
+              |{"code":"200","content":[]}
+              |""".stripMargin)).
+          thenReturn(buildResp(
+            """
+              |{"code":"200","content":[]}
+              |""".stripMargin))
+
+        when(reqMock.execute()).thenReturn(responseMock)
+        reqStatic => {
+          autoGenerateContext(runtime)
+          val rest = new MLSQLRest()
+          val session = ScriptSQLExec.context().execListener.sparkSession
+          val res = rest.load(session.read, DataSourceConfig(
+            "http://www.byzer.org/list", Map(
+              "config.page.next" -> "http://www.byzer.org/list?{0}",
+              "config.page.values" -> "auto-increment:0",
+              "config.page.stop" -> "sizeZero:$.content",
+              "config.page.limit" -> "4",
+              "config.debug" -> "true",
+            ), Option(session.emptyDataFrame)
+          ))
+          val rows = res.collect()
+          rows.foreach(println(_))
+          // the last one will also been append in the result with empty value
+          assertEquals(3, rows.length)
+        }
+      }
+
+    }
+
+  }
+}


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [x] Finshed changes describe

Add a new config in Rest Datasource: `config.page.stop` which to control when the page fetching should stop.

# How was this patch tested?
- [x] Testing done

```
tech.mlsql.test.ds.MLSQLRestTest
```
# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
