### PR TITLE
Let Byzer-lang invoke callback if Java UDf is not compilable

### DIFF
--- a/streamingpro-core/src/main/java/streaming/udf/RuntimeCompileUDF.scala
+++ b/streamingpro-core/src/main/java/streaming/udf/RuntimeCompileUDF.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ScalaUDF, WowScala
 import org.apache.spark.sql.types.DataType
 import streaming.dsl.ScriptSQLExec
 import streaming.dsl.mmlib.algs.ScriptUDFCacheKey
+import tech.mlsql.common.utils.concurrent.ExecutionError
 
 /**
   * Created by fchen on 2018/11/15.
@@ -49,7 +50,12 @@ trait RuntimeCompileUDF extends RuntimeCompileScriptInterface[AnyRef] {
 
   override def generateFunction(scriptCacheKey: ScriptUDFCacheKey): AnyRef = {
     val runtimeFunction = invokeFunctionFromInstance(scriptCacheKey)
-    toPartialFunc(scriptCacheKey, runtimeFunction)
+    try {
+      toPartialFunc(scriptCacheKey, runtimeFunction)
+    }
+    catch {
+      case e: ExecutionError => throw new RuntimeException(e.getCause)
+    }
   }
 
   def udf(exp: Seq[Expression], scriptCacheKey: ScriptUDFCacheKey): ScalaUDF = {

--- a/streamingpro-it/src/test/resources/sql/simple/21_java_udf_compile.mlsql
+++ b/streamingpro-it/src/test/resources/sql/simple/21_java_udf_compile.mlsql
@@ -1,0 +1,23 @@
+--%exception=java.lang.RuntimeException
+--%msg=java.lang.ClassFormatError: Truncated class file
+
+
+REGISTER ScriptUDF.`` AS echoFun WHERE
+and lang="java"
+and udfType="udf"
+and className="Test"
+and methodName="test"
+and code='''
+import java.util.HashMap;
+import java.util.Map;
+public class Test {
+    public Map<String, String> test(String s) {
+      Map m = new HashMap<>();
+      m.put(s, s);
+      return m
+  }
+}
+''';
+
+select echoFun("a") as output;
+

--- a/streamingpro-it/src/test/resources/sql/simple/22_scala_udf_compile.mlsql
+++ b/streamingpro-it/src/test/resources/sql/simple/22_scala_udf_compile.mlsql
@@ -1,0 +1,50 @@
+--%exception=java.util.concurrent.ExecutionException
+--%msg=scala.tools.reflect.ToolBoxError: reflective compilation has failed(.*?)\n+(.*?)
+
+SET plusFun='''
+import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+class SumAggregation extends UserDefinedAggregateFunction with Serializable{
+    def inputSchema: StructType = new StructType().add("a", LongType)
+    def bufferSchema: StructType =  new StructType().add("total", LongType)
+    def dataType: DataType = LongType
+    def deterministic: Boolean = true
+
+    def initialize(buffer: MutableAggregationBuffer): Unit = {
+      // Compile error here
+      buffer.update(0, 0l
+    }
+
+    def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+      val sum   = buffer.getLong(0)
+      val newitem = input.getLong(0)
+      buffer.update(0, sum + newitem)
+    }
+
+    def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+      buffer1.update(0, buffer1.getLong(0) + buffer2.getLong(0))
+    }
+
+    def evaluate(buffer: Row): Any = {
+      buffer.getLong(0)
+    }
+}
+''';
+
+LOAD script.`plusFun` AS scriptTable;
+
+REGISTER ScriptUDF.`scriptTable` AS plusFun options
+className="SumAggregation"
+and udfType="udaf";
+
+SET data='''
+{"a":1}
+{"a":1}
+{"a":1}
+{"a":1}
+''';
+
+LOAD jsonStr.`data` AS dataTable;
+
+SELECT a,plusFun(a) AS res FROM dataTable GROUP BY a AS output;

--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestUtils.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestUtils.scala
@@ -17,11 +17,6 @@ object RestUtils {
        .map{ case (name, value) => new BasicNameValuePair(name, value) }.toSeq
 
     Request.Post(urlString)
-      // Socket timeout is in milliseconds, default to 20 minutes
-      // TODO this should be configurable
-      .socketTimeout(20 * 60 * 1000 )
-      // Timeout to obtain Socket connection
-      .connectTimeout(10 * 1000)
       .addHeader("Content-Type", "application/x-www-form-urlencoded")
       .body(new UrlEncodedFormEntity(nameValuePairs.asJava, DefaultHttpTransportService.charset))
       .execute()

--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestUtils.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestUtils.scala
@@ -17,6 +17,11 @@ object RestUtils {
        .map{ case (name, value) => new BasicNameValuePair(name, value) }.toSeq
 
     Request.Post(urlString)
+      // Socket timeout is in milliseconds, default to 20 minutes
+      // TODO this should be configurable
+      .socketTimeout(20 * 60 * 1000 )
+      // Timeout to obtain Socket connection
+      .connectTimeout(10 * 1000)
       .addHeader("Content-Type", "application/x-www-form-urlencoded")
       .body(new UrlEncodedFormEntity(nameValuePairs.asJava, DefaultHttpTransportService.charset))
       .execute()


### PR DESCRIPTION
# What changes were proposed in this pull request?

Github issue link: #1699 

## Issue Description

The following Java UDF has syntax error, ; is missing at the end of line 13; Byzer should report it and not run it.

```sql
REGISTER ScriptUDF.`` AS echoFun WHERE 
and lang="java"
and udfType="udf"
and className="Test"
and methodName="test"
and code='''
import java.util.HashMap;
import java.util.Map;
public class Test {
    public Map<String, String> test(String s) {
      Map m = new HashMap<>();
      m.put(s, s);
      return m
  }
}
''';

select echoFun("a") as output;
```

However, Byzer-lang Notebook remains in running status , and dooes not report the error. 

## Cause analysis 

Digging into Byzer-lang log, I've found the exception stack. 

```text
Exception in thread "pool-23-thread-5" tech.mlsql.common.utils.concurrent.ExecutionError: java.lang.ClassFormatError: Truncated class file
        at tech.mlsql.common.utils.cache.LocalCache$Segment.get(LocalCache.java:2157)
        at streaming.udf.RuntimeCompileScriptInterface.driverExecute(RuntimeCompileScriptInterface.scala:39)        
        at streaming.udf.JavaRuntimeCompileUDF$.argumentNum(JavaRuntimeCompileUDF.scala:29)        
        at streaming.udf.RuntimeCompileUDF.generateFunction(RuntimeCompileUDF.scala:52)        
        at streaming.udf.JavaRuntimeCompileUDF$.generateFunction(JavaRuntimeCompileUDF.scala:13)
        at streaming.udf.RuntimeCompileUDF.udf(RuntimeCompileUDF.scala:57)        
        at streaming.udf.JavaRuntimeCompileUDF$.udf(JavaRuntimeCompileUDF.scala:13)
        at streaming.dsl.mmlib.algs.ScriptUDF.$anonfun$load$8(ScriptUDF.scala:93)
        at org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistry.lookupFunction(FunctionRegistry.scala:121)      
        at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1(RuleExecutor.scala:213)        
        at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:610)
        at tech.mlsql.dsl.adaptor.SelectAdaptor.parse(SelectAdaptor.scala:73)        
        at streaming.dsl.ScriptSQLExec$._parse(ScriptSQLExec.scala:160)        
        at streaming.rest.RestController.$anonfun$script$1(RestController.scala:153)       
```

The logs shows that an `ExecutionError` is thrown during UDF compilation. Byzer-lang failed to handle it. 
```Java
public class ExecutionError extends Error 
```


### Solution
Catch `ExecutionError` during UDF compilation, turn it into RuntimeException; so that RestController would invoke callback.


# How was this patch tested?
Two new integration test cases:
- 21_java_udf_compile.mlsql
- 22_scala_udf_compile.mlsql

# Are there and DOC need to update?
- No Doc change

# Spark Core Compatibility
Spark 2.x & 3.x 