### PR TITLE
[Bug] 修复语法提示未匹配时导致 NoSuchElementException 的报错问题。Fix the NoSuchElementException error when syntax hint is not matched.

### DIFF
--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/LexerUtils.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/LexerUtils.scala
@@ -8,6 +8,7 @@ import tech.mlsql.autosuggest.dsl.{MLSQLTokenTypeWrapper, TokenTypeWrapper}
 import tech.mlsql.autosuggest.{AutoSuggestContext, TokenPos, TokenPosType}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 
 /**
  * 1/6/2020 WilliamZhu(allwefantasy@gmail.com)
@@ -62,23 +63,32 @@ object LexerUtils {
     if (tokens.size == 0) {
       return TokenPos(-1, TokenPosType.NEXT, -1)
     }
-
     val oneLineTokens = tokens.zipWithIndex.filter { case (token, index) =>
       token.getLine == lineNum
     }
-
+    var lineNumList:ListBuffer[Int] = ListBuffer[Int]()
+    tokens.foreach(token => lineNumList += token.getLine)
+    lineNumList = lineNumList.distinct
+    var headTokenLineNum:Int = lineNum-1
+    var lastTokenLineNum:Int = lineNum+1
+    if(headTokenLineNum > lineNumList.last){
+      headTokenLineNum = lineNumList.last
+    }
+    if(lastTokenLineNum > lineNumList.last){
+      lastTokenLineNum = lineNumList.last
+    }
     val firstToken = oneLineTokens.headOption match {
       case Some(head) => head
       case None =>
         tokens.zipWithIndex.filter { case (token, index) =>
-          token.getLine == lineNum - 1
+          token.getLine == headTokenLineNum
         }.head
     }
     val lastToken = oneLineTokens.lastOption match {
       case Some(last) => last
       case None =>
         tokens.zipWithIndex.filter { case (token, index) =>
-          token.getLine == lineNum + 1
+          token.getLine == lastTokenLineNum
         }.last
     }
 
@@ -141,19 +151,29 @@ object LexerUtils {
     val oneLineTokens = tokens.zipWithIndex.filter { case (token, index) =>
       token.getLine == lineNum
     }
-
+    var lineNumList:ListBuffer[Int] = ListBuffer[Int]()
+    tokens.foreach(token => lineNumList += token.getLine)
+    lineNumList = lineNumList.distinct
+    var headTokenLineNum:Int = lineNum-1
+    var lastTokenLineNum:Int = lineNum+1
+    if(headTokenLineNum > lineNumList.last){
+      headTokenLineNum = lineNumList.last
+    }
+    if(lastTokenLineNum > lineNumList.last){
+      lastTokenLineNum = lineNumList.last
+    }
     val firstToken = oneLineTokens.headOption match {
       case Some(head) => head
       case None =>
         tokens.zipWithIndex.filter { case (token, index) =>
-          token.getLine == lineNum - 1
+          token.getLine == headTokenLineNum
         }.head
     }
     val lastToken = oneLineTokens.lastOption match {
       case Some(last) => last
       case None =>
         tokens.zipWithIndex.filter { case (token, index) =>
-          token.getLine == lineNum + 1
+          token.getLine == lastTokenLineNum
         }.last
     }
 
@@ -194,6 +214,7 @@ object LexerUtils {
 
     }.filterNot(_.pos == -2).head
   }
+
 
   def isInWhereContext(tokens: List[Token], tokenPos: Int): Boolean = {
     if (tokenPos < 1) return false

--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/LexerUtils.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/statement/LexerUtils.scala
@@ -60,36 +60,30 @@ object LexerUtils {
      * load[cursor]         in token
      */
 
-    if (tokens.size == 0) {
+    if (tokens.isEmpty) {
       return TokenPos(-1, TokenPosType.NEXT, -1)
     }
+    val _lastToken: Token = tokens.last
+    var _lastTokenIndex = 0
+    var _lastLineHeadToken: Token = _lastToken
+    var _lastLineHeadTokenNum: Int = -1
+    var _lastLineHeadTokenIndex = 0
     val oneLineTokens = tokens.zipWithIndex.filter { case (token, index) =>
+      _lastTokenIndex = index
+      if (_lastLineHeadTokenNum != token.getLine) {
+        _lastLineHeadTokenIndex = index
+        _lastLineHeadToken = token
+        _lastLineHeadTokenNum = token.getLine
+      }
       token.getLine == lineNum
-    }
-    var lineNumList:ListBuffer[Int] = ListBuffer[Int]()
-    tokens.foreach(token => lineNumList += token.getLine)
-    lineNumList = lineNumList.distinct
-    var headTokenLineNum:Int = lineNum-1
-    var lastTokenLineNum:Int = lineNum+1
-    if(headTokenLineNum > lineNumList.last){
-      headTokenLineNum = lineNumList.last
-    }
-    if(lastTokenLineNum > lineNumList.last){
-      lastTokenLineNum = lineNumList.last
     }
     val firstToken = oneLineTokens.headOption match {
       case Some(head) => head
-      case None =>
-        tokens.zipWithIndex.filter { case (token, index) =>
-          token.getLine == headTokenLineNum
-        }.head
+      case None => (_lastLineHeadToken, _lastLineHeadTokenIndex)
     }
     val lastToken = oneLineTokens.lastOption match {
       case Some(last) => last
-      case None =>
-        tokens.zipWithIndex.filter { case (token, index) =>
-          token.getLine == lastTokenLineNum
-        }.last
+      case None => (_lastToken, _lastTokenIndex)
     }
 
     if (colNum < firstToken._1.getCharPositionInLine) {
@@ -144,37 +138,30 @@ object LexerUtils {
      * load[cursor]         in token
      */
 
-    if (tokens.size == 0) {
+    if (tokens.isEmpty) {
       return TokenPos(-1, TokenPosType.NEXT, -1)
     }
-
+    val _lastToken: Token = tokens.last
+    var _lastTokenIndex = 0
+    var _lastLineHeadToken: Token = _lastToken
+    var _lastLineHeadTokenNum: Int = -1
+    var _lastLineHeadTokenIndex = 0
     val oneLineTokens = tokens.zipWithIndex.filter { case (token, index) =>
+      _lastTokenIndex = index
+      if (_lastLineHeadTokenNum != token.getLine) {
+        _lastLineHeadTokenIndex = index
+        _lastLineHeadToken = token
+        _lastLineHeadTokenNum = token.getLine
+      }
       token.getLine == lineNum
-    }
-    var lineNumList:ListBuffer[Int] = ListBuffer[Int]()
-    tokens.foreach(token => lineNumList += token.getLine)
-    lineNumList = lineNumList.distinct
-    var headTokenLineNum:Int = lineNum-1
-    var lastTokenLineNum:Int = lineNum+1
-    if(headTokenLineNum > lineNumList.last){
-      headTokenLineNum = lineNumList.last
-    }
-    if(lastTokenLineNum > lineNumList.last){
-      lastTokenLineNum = lineNumList.last
     }
     val firstToken = oneLineTokens.headOption match {
       case Some(head) => head
-      case None =>
-        tokens.zipWithIndex.filter { case (token, index) =>
-          token.getLine == headTokenLineNum
-        }.head
+      case None => (_lastLineHeadToken, _lastLineHeadTokenIndex)
     }
     val lastToken = oneLineTokens.lastOption match {
       case Some(last) => last
-      case None =>
-        tokens.zipWithIndex.filter { case (token, index) =>
-          token.getLine == lastTokenLineNum
-        }.last
+      case None => (_lastToken, _lastTokenIndex)
     }
 
     if (colNum < firstToken._1.getCharPositionInLine) {
@@ -288,3 +275,4 @@ object LexerUtils {
     }.filter(_ != null)
   }
 }
+


### PR DESCRIPTION
Solve the NoSuchElementException that the firstToken and lastToken of LexerUtils.scala trigger None during match

# What changes were proposed in this pull request?
- [ ] Finshed changes describe
Solve the NoSuchElementException that the firstToken and lastToken of LexerUtils.scala trigger None during match
# How was this patch tested?
- [ ] Testing done
<img width="919" alt="截屏2022-03-23 00 07 23" src="https://user-images.githubusercontent.com/70516188/159524627-f6365ff1-f3e9-4f86-a420-8dbb951c213e.png">
<img width="1152" alt="截屏2022-03-23 00 07 55" src="https://user-images.githubusercontent.com/70516188/159524672-1a895e3b-8bae-41f9-87e0-b3a409838f4b.png">


# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
