### PR TITLE
Update LexerUtils.scala

### DIFF
--- a/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/AutoSuggestContext.scala
+++ b/external/mlsql-autosuggest/src/main/java/tech/mlsql/autosuggest/AutoSuggestContext.scala
@@ -167,7 +167,7 @@ class AutoSuggestContext(val session: SparkSession,
   private[autosuggest] def _suggest(tokenPos: TokenPos): List[SuggestItem] = {
     assert(_rawColumnNum != 0 || _rawLineNum != 0, "lineNum and columnNum should be set")
     if (isInDebugMode) {
-      logInfo("Global Pos::" + tokenPos.str + s"::${rawTokens(tokenPos.pos)}")
+      logInfo("Global Pos::" + tokenPos.str + s"::${if(tokenPos.pos == -1) null else rawTokens(tokenPos.pos)}")
     }
     if (tokenPos.pos == -1) {
       return firstWords

--- a/external/mlsql-autosuggest/src/test/java/com/intigua/antlr4/autosuggest/LexerUtilsTest.scala
+++ b/external/mlsql-autosuggest/src/test/java/com/intigua/antlr4/autosuggest/LexerUtilsTest.scala
@@ -1,13 +1,12 @@
 package com.intigua.antlr4.autosuggest
 
 import tech.mlsql.autosuggest.statement.LexerUtils
-import tech.mlsql.autosuggest.{TokenPos, TokenPosType}
+import tech.mlsql.autosuggest.{AutoSuggestContext, TokenPos, TokenPosType}
 
 /**
  * 2/6/2020 WilliamZhu(allwefantasy@gmail.com)
  */
 class LexerUtilsTest extends BaseTest {
-
   test(" load [cursor]hive.`` as -- jack") {
     assert(LexerUtils.toTokenPos(tokens, 3, 6) == TokenPos(0, TokenPosType.NEXT, 0))
 
@@ -42,5 +41,40 @@ class LexerUtilsTest extends BaseTest {
     context.buildFromString("load csv.")
     assert(LexerUtils.toTokenPos(context.rawTokens, 1, 9) == TokenPos(2, TokenPosType.NEXT, 0))
   }
-
+  test("select a,b,c from table1 as table1;select aa,bb,cc from table2 as table2;\\n \\n \\n select from table1 t1  left join table2 t2  on t1.a = t2."){
+    val sql ="""
+               |select a,b,c from table1 as table1;
+               |select aa,bb,cc from table2 as table2;
+               |
+               |
+               |
+               |select from table1 t1  left join table2 t2  on t1.a = t2.
+               |""".stripMargin
+    val items = context.buildFromString(sql).suggest(4, 0)
+    assert(items.map(_.name) == List("load", "select", "include","register","run","train","predict","save","set"))
+  }
+  test("select a,b,c from table1 as table1;select \\n \\n \\n select from table1 t1  left join table2 t2  on t1.a = t2."){
+    val sql ="""
+               |select a,b,c from table1 as table1;
+               |select
+               |
+               |
+               |
+               |select from table1 t1  left join table2 t2  on t1.a = t2.
+               |""".stripMargin
+    val items = context.buildFromString(sql).suggest(4, 0)
+    assert(items.map(_.name) == List("table1", "a", "b", "c"))
+  }
+  test("select a,b,c from table1 as table1;select aa,bb,cc from table2 as table2;select from table1 t1  left join table2 t2  on t1.a = t2. \\n"){
+    val sql ="""
+               |select a,b,c from table1 as table1;
+               |select aa,bb,cc from table2 as table2;
+               |select from table1 t1  left join table2 t2  on t1.a = t2
+               |
+               |
+               |""".stripMargin
+    AutoSuggestContext.init
+    val items = context.buildFromString(sql).suggest(5, 0)
+    assert(items.map(_.name) == List("table1", "table2", "aa", "bb", "cc", "a", "b", "c","count", "split"))
+  }
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [ ] Finshed changes describe
Optimized the logic of LexerUtils.scala for blank line judgment.
When the last word on the previous line of the cursor is ";", the complex judgment logic that follows will no longer be executed.
# How was this patch tested?
- [ ] Testing done
<img width="1060" alt="截屏2022-03-28 02 56 56" src="https://user-images.githubusercontent.com/70516188/160296413-a47ff927-8541-4a1b-b591-0217ed4631e5.png">
<img width="961" alt="截屏2022-03-28 02 57 06" src="https://user-images.githubusercontent.com/70516188/160296424-1ad186ad-e2da-4871-abc1-743b627e0d37.png">
<img width="942" alt="截屏2022-03-28 02 57 33" src="https://user-images.githubusercontent.com/70516188/160296434-65078e52-18f1-487e-b896-eebd734f245d.png">

There are two states: no code below the cursor and code below the cursor.
If the last word of the line above the cursor is ";", then the semantics of the statement is considered to end, and TokenPos(-1, TokenPosType.NEXT, -1) is returned.

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
