### PR TITLE
MLSQLRest returns more informative response for different types of errors

### DIFF
--- a/streamingpro-core/src/test/scala/tech/mlsql/crawler/RestUtilsTest.scala
+++ b/streamingpro-core/src/test/scala/tech/mlsql/crawler/RestUtilsTest.scala
@@ -1,0 +1,21 @@
+package tech.mlsql.crawler
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import tech.mlsql.common.utils.log.Logging
+
+class RestUtilsTest extends AnyFlatSpec with should.Matchers with Logging {
+
+  "executeWithRetrying " should "run at most 3 times" in {
+    var numExecuted = 0;
+    RestUtils.executeWithRetrying[Int](3)(  {
+      numExecuted += 1
+      numExecuted
+    }, _ => {
+      false
+    }, _ => {
+      logInfo("Failing execution")
+    })
+    assert( numExecuted == 3 )
+  }
+}

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/DefaultPageStrategy.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/helper/rest/DefaultPageStrategy.scala
@@ -7,7 +7,11 @@ import tech.mlsql.tool.Templates2
  * 3/12/2021 WilliamZhu(allwefantasy@gmail.com)
  */
 class DefaultPageStrategy(params: Map[String, String]) extends PageStrategy {
-
+  /**
+   * Extracts page values from content by jsonPath.
+   * @param _content
+   * @return
+   */
   def pageValues(_content: Option[Any]): Array[String] = {
     try {
       val content = _content.get.toString
@@ -30,12 +34,12 @@ class DefaultPageStrategy(params: Map[String, String]) extends PageStrategy {
   }
 
   override def hasNextPage(_content: Option[Any]): Boolean = {
-    if (params.get("config.page.stop").isDefined) {
-      PageStrategy.defaultHasNextPage(params, _content)
-    } else {
-      val pageValues = this.pageValues(_content)
-      !(pageValues.size == 0 || pageValues.filter(value => value == null || value.isEmpty).size > 0)
+    params.get("config.page.stop") match {
+      case Some(_) =>
+        PageStrategy.defaultHasNextPage(params, _content)
+      case None =>
+        val pageValues = this.pageValues(_content)
+        !(pageValues.size == 0 || pageValues.exists(value => value == null || value.isEmpty))
     }
-
   }
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
1. Fixed RestUtils.executeWithRetrying executes one more time than expected.
2. MLSQLRest load function refactoring and 4 new test cases.
3. More informative response 

##  RestUtils.executeWithRetrying executes one more time than expected.
In the old implementation, function executes at least two times. It's fixed now, and is covered  by  test case in RestUtilsTest
```
 def executeWithRetrying[T](maxTries: Int)(function: => T, checker: T => Boolean, failed: T => Unit): T = {
   // Run the function for the first time
    var result: T = function
    if (checker(result)) {
      return result
    }

    breakable {
      for (i <- 0 until maxTries) {
       // Run again even if maxTries == 1
        result = function
        if (checker(result)) {
          break
        }
        if (i == maxTries - 1) {
          failed(result)
        }
      }
    }
    result
  }
```

## MLSQLRest load function refactoring 
The logic to call http endpoints with retrying is repated 3 times with small differences. Now , we encapsulate it in 
`_httpWithRetrying`.   For pagnation,  use do while loop to avoid reapted code. 

Since it's a big change,  4 new caes are added.  And unit test covers
- Single page http rest
- Three pagination strategies: auto-increment, default and offset st.
- Stop strategy : bad status-code, config.page.limit, sizeZero, equals

## More informative response 
Now, MLSQLRest returns 
- 405 for unsupported http method 
-  415 for unsupported content-type 
- 0 for `Exception` such as UnknownHost.
- 4xx for client side errors
- 5xx for server side errors

# How was this patch tested?
MLSQLRest test result
![image](https://user-images.githubusercontent.com/12869649/161714622-ce7e2646-0c0a-4de8-882f-77dfdcaf24cb.png)

RestUtils test result
![image](https://user-images.githubusercontent.com/12869649/161718810-9a92f343-813c-46ef-a0e7-ae88d7ea0fac.png)


# Are there and DOC need to update?
- Changes does not impact current documents.

# Spark Core Compatibility
