### PR TITLE
fix script & assembly

### DIFF
--- a/dev/byzer.sh
+++ b/dev/byzer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dev/check-1000-java.sh
+++ b/dev/check-1000-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dev/check-1100-ports.sh
+++ b/dev/check-1100-ports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,7 +26,7 @@ if [[ -z ${byzer_lang_port} ]]; then
     byzer_lang_port=9003
 fi
 if [[ $MACHINE_OS == "Linux" ]]; then
-    byzer_lang_port_in_use=`netstat -anvp tcp | grep "\b${byzer_lang_port}\b"`
+    byzer_lang_port_in_use=`netstat -nat | grep "${byzer_lang_port}"`
 fi
 if [[ $MACHINE_OS == "Mac" ]]; then
     byzer_lang_port_in_use=`lsof -nP -iTCP:${byzer_lang_port} -sTCP:LISTEN`

--- a/dev/check-env.sh
+++ b/dev/check-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dev/get-properties.sh
+++ b/dev/get-properties.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/dev/header.sh
+++ b/dev/header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
@@ -118,5 +118,4 @@ then
         *)          os="UNKNOWN:${unameOut}"
     esac
     export MACHINE_OS=$os
-
 fi

--- a/dev/kill-process-tree.sh
+++ b/dev/kill-process-tree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/streamingpro-assembly/src/main/assembly/assembly.xml
+++ b/streamingpro-assembly/src/main/assembly/assembly.xml
@@ -22,10 +22,8 @@
                 <include>check-1000-java.sh</include>
                 <include>check-1100-ports.sh</include>
                 <include>get-properties.sh</include>
-                <include>headers.sh</include>
+                <include>header.sh</include>
                 <include>kill-process-tree.sh</include>
-                <include>log-rotate-cron.sh</include>
-                <include>rotate-logs.sh</include>
             </includes>
             <outputDirectory>bin</outputDirectory>
         </fileSet>


### PR DESCRIPTION
# What changes were proposed in this pull request?
fix script & assembly.xml

# How was this patch tested?
Package &run in linux env:
### start
```
./byzer.sh start
Starting Byzer-lang...

Byzer-lang is checking installation environment, log is at /home/byzer/byzer-lang-3.1.1-2.3.0-SNAPSHOT/logs/check-env.out

Checking Java Version
...................................................[PASS]
Checking Ports Availability
...................................................[PASS]

Checking environment finished successfully. To check again, run 'bin/check-env.sh' manually.

SPARK_HOME is:/usr/local/spark
BYZER_HOME is:/home/byzer/byzer-lang-3.1.1-2.3.0-SNAPSHOT
BYZER_CONFIG_FILE is:/home/byzer/byzer-lang-3.1.1-2.3.0-SNAPSHOT/conf/byzer.properties
Checking rest port on Linux
9003 is available
Starting Byzer-lang...
[Spark config]
--conf spark.kryoserializer.buffer.max=1024m
--conf spark.scheduler.mode=FAIR
--conf spark.kryoserializer.buffer=256k
--conf spark.master=local[*]
--conf spark.driver.memory=2g
--conf spark.serializer=org.apache.spark.serializer.KryoSerializer
--conf spark.sql.hive.thriftServer.singleSession=true
[Byzer config]
-streaming.name byzer-lang
-streaming.driver.port 9003
-streaming.rest true
-streaming.enableHiveSupport false
-streaming.platform spark
-streaming.spark.service true
-streaming.thrift false
[Extra config]
/home/byzer/byzer-lang-3.1.1-2.3.0-SNAPSHOT/libs/*.jar:/home/byzer/byzer-lang-3.1.1-2.3.0-SNAPSHOT/main/byzer-lang-3.1.1-2.12-2.3.0-SNAPSHOT.jar
Byzer-lang is starting. It may take a while. For status, please visit http://172.17.0.1:9003.
You may also check status via: PID:37463, or Log: /home/byzer/byzer-lang-3.1.1-2.3.0-SNAPSHOT/logs/byzer.log.
```
### stop
```
./byzer.sh stop
2022-04-21 02:23:14 Stopping Byzer-lang...
2022-04-21 02:23:14 Stopping Byzer-lang: 37463
```

# Are there and DOC need to update?
N/A

# Spark Core Compatibility
