### PR TITLE
Upgrade MLSQLRest test case

### DIFF
--- a/streamingpro-core/src/test/scala/tech/mlsql/runtime/FunctionsTest.scala
+++ b/streamingpro-core/src/test/scala/tech/mlsql/runtime/FunctionsTest.scala
@@ -42,15 +42,15 @@ import scala.language.reflectiveCalls
 
 class FunctionsTest extends AnyFlatSpec with should.Matchers {
 
+  /**
+   * This function mocks a Request. For any request url, get & post, bodyForm & bodyString,
+   * A response is returned with http status 200
+   * @param reqStatic
+   */
   def initRest(reqStatic: MockedStatic[Request]): Unit = {
+
     val reqMock = mock(classOf[Request])
-    val httpResp: HttpResponse = new BasicHttpResponse(new BasicStatusLine(
-      new ProtocolVersion("HTTP", 1, 1), 200, ""))
-    val entity = new BasicHttpEntity()
-    entity.setContent(new ByteArrayInputStream("{\"code\":\"200\",\"content\":\"ok\"}".getBytes()))
-    httpResp.setEntity(entity)
-    val responseMock = mock(classOf[Response])
-    when(responseMock.returnResponse()).thenReturn(httpResp)
+
     // Get
     reqStatic.when(new MockedStatic.Verification() {
       override def apply(): Unit = {
@@ -66,6 +66,17 @@ class FunctionsTest extends AnyFlatSpec with should.Matchers {
     when(reqMock.bodyString(anyString, ArgumentMatchers.any())).thenReturn(reqMock)
     // Post bodyForm
     when(reqMock.bodyForm(anyList(), ArgumentMatchers.any())).thenReturn(reqMock)
+
+    // Mock Response
+    val httpResp: HttpResponse = new BasicHttpResponse(new BasicStatusLine(
+      new ProtocolVersion("HTTP", 1, 1), 200, ""))
+    val entity = new BasicHttpEntity()
+    entity.setContent(new ByteArrayInputStream("{\"code\":\"200\",\"content\":\"ok\"}".getBytes()))
+    httpResp.setEntity(entity)
+    val responseMock = mock(classOf[Response])
+    when(reqMock.execute()).thenReturn(responseMock)
+    when(responseMock.returnResponse()).thenReturn(httpResp)
+
   }
 
   "A http GET request" should "return then mock result" in {
@@ -114,7 +125,7 @@ class FunctionsTest extends AnyFlatSpec with should.Matchers {
           params = Map("body" -> "{\"a\":1,\"b\":2}"), headers = Map("Content-Type" -> "application/json"), Map())
 
         println(s"status:$status, content:$content")
-        assertEquals(status, 200)
+        assertEquals(200, status )
         assertEquals(content, "{\"code\":\"200\",\"content\":\"ok\"}")
         // verify url concat is legal.
         reqStatic.verify(new MockedStatic.Verification() {

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/MLSQLRest.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/datasource/impl/MLSQLRest.scala
@@ -139,7 +139,7 @@ class MLSQLRest(override val uid: String) extends MLSQLSource
 
         val uuid = UUID.randomUUID().toString.replaceAll("-", "")
         val context = ScriptSQLExec.context()
-        // each page's result is save in tmpTablePath
+        // each page's result is saved in tmpTablePath
         val tmpTablePath = resourceRealPath(context.execListener, Option(context.owner),
           PathFun("__tmp__").add("rest").add(uuid).toPath)
         context.execListener.addEnv(classOf[MLSQLRest].getName, tmpTablePath)


### PR DESCRIPTION
# What changes were proposed in this pull request?
1. Fix failed test in FunctionsTest
2. Change offset pagination test case, so that it mocks different responses during pagination.

# How was this patch tested?
- MLSQLRestTest passed
- FunctionsTest passed
![image](https://user-images.githubusercontent.com/12869649/166633161-034cd2d0-9bc5-4974-b8d4-de2c7ced9000.png)
![image](https://user-images.githubusercontent.com/12869649/166633214-5dc9ad65-95c4-4179-92d4-20f4538b67b7.png)

# Are there and DOC need to update?
- No changes to DOC

# Spark Core Compatibility
