### PR TITLE
Add pathPrefix for modelExplain

### DIFF
--- a/streamingpro-core/src/main/java/streaming/dsl/load/batch/ModelExplain.scala
+++ b/streamingpro-core/src/main/java/streaming/dsl/load/batch/ModelExplain.scala
@@ -21,6 +21,7 @@ package streaming.dsl.load.batch
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import tech.mlsql.dsl.adaptor.MLMapping
+import tech.mlsql.tool.HDFSOperatorV2
 
 
 /**
@@ -217,7 +218,32 @@ class ModelExplain(format: String, path: String, option: Map[String, String])(sp
     if ((format == "model" && path == "explain"))
       option("path")
     else {
-      path
+      option.get("index") match {
+          // If user specifies index, try to find _model_n subdirectory
+        case Some(idx) =>
+          val subDirs = HDFSOperatorV2.listFiles(path)
+              .filter( _.isDirectory )
+          val _modelDirExists = subDirs.exists( _.getPath.getName.startsWith("_model_"))
+          val _modelIdxDirExists = subDirs.exists( s"_model_${idx}" == _.getPath.getName)
+          val metaDirExists =  subDirs.exists( "meta" == _.getPath.getName)
+          val modelDirExists = subDirs.exists( "model" == _.getPath.getName)
+          if( _modelDirExists && _modelIdxDirExists) {
+            s"${path}/_model_${idx}"
+          }
+          else if( _modelDirExists && ! _modelIdxDirExists ) {
+            throw new RuntimeException(s"model directory with index ${idx} does not exist")
+          }
+          else if( metaDirExists && modelDirExists ) {
+            // `keepVersion`="false", index option is ignored.
+            path
+          }
+          else {
+            throw new RuntimeException(s"${path}/_model_${idx} does not exist")
+          }
+
+          // If keepVersion is not enabled
+        case None => path
+      }
     }
   }
 

--- a/streamingpro-core/src/main/java/streaming/dsl/load/batch/ModelExplain.scala
+++ b/streamingpro-core/src/main/java/streaming/dsl/load/batch/ModelExplain.scala
@@ -20,10 +20,8 @@ package streaming.dsl.load.batch
 
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import tech.mlsql.common.utils.reflect.ClassPath
 import tech.mlsql.dsl.adaptor.MLMapping
 
-import scala.collection.JavaConversions._
 
 /**
   * Created by allwefantasy on 21/9/2018.

--- a/streamingpro-it/src/test/resources/sql/simple/23_random_forest_model_explain.mlsql
+++ b/streamingpro-it/src/test/resources/sql/simple/23_random_forest_model_explain.mlsql
@@ -1,0 +1,38 @@
+--%comparator=tech.mlsql.it.IgnoreResultComparator
+
+set jsonStr='''
+{"features":[5.1,3.5,1.4,0.2],"label":0.0},
+{"features":[5.1,3.5,1.4,0.2],"label":1.0}
+{"features":[5.1,3.5,1.4,0.2],"label":0.0}
+{"features":[4.4,2.9,1.4,0.2],"label":0.0}
+{"features":[5.1,3.5,1.4,0.2],"label":1.0}
+{"features":[5.1,3.5,1.4,0.2],"label":0.0}
+{"features":[5.1,3.5,1.4,0.2],"label":0.0}
+{"features":[4.7,3.2,1.3,0.2],"label":1.0}
+{"features":[5.1,3.5,1.4,0.2],"label":0.0}
+{"features":[5.1,3.5,1.4,0.2],"label":0.0}
+''';
+load jsonStr.`jsonStr` as mock_data;
+
+
+select vec_dense(features) as features, label as label from mock_data as mock_data_1;
+
+
+train mock_data_1 as RandomForest.`/tmp/model` where
+keepVersion="true"
+and evaluateTable="mock_data_validate"
+
+and `fitParam.0.labelCol`="label"
+and `fitParam.0.featuresCol`="features"
+and `fitParam.0.maxDepth`="2"
+
+and `fitParam.1.featuresCol`="features"
+and `fitParam.1.labelCol`="label"
+and `fitParam.1.maxDepth`="10"
+;
+
+load modelExplain.`/tmp/model/_model_0/` where alg="RandomForest" as output_1;
+
+select `name` from output_1 where name="uid" as result;
+
+!assert result ''':name=="uid"'''  "RandomForest modelExplain should be successful";

--- a/streamingpro-it/src/test/resources/sql/simple/23_random_forest_model_explain.mlsql
+++ b/streamingpro-it/src/test/resources/sql/simple/23_random_forest_model_explain.mlsql
@@ -36,3 +36,8 @@ load modelExplain.`/tmp/model/_model_0/` where alg="RandomForest" as output_1;
 select `name` from output_1 where name="uid" as result;
 
 !assert result ''':name=="uid"'''  "RandomForest modelExplain should be successful";
+
+
+load modelExplain.`/tmp/model/_model_0/` where alg="RandomForest" and index = "0" as output_2;
+select `name` from output_2 where name="uid" as result_2;
+!assert result_2 ''':name=="uid"'''  "RandomForest modelExplain should be successful";

--- a/streamingpro-it/src/test/resources/sql/simple/andie_huang_02_train_linear_regression_model.mlsql
+++ b/streamingpro-it/src/test/resources/sql/simple/andie_huang_02_train_linear_regression_model.mlsql
@@ -49,3 +49,10 @@ select pred_func(features) as predict_label, label from data1 as output;
 select name,value from model_result where name="status" as result;
 -- make sure status of  all models are success.
 !assert result ''':value=="success"'''  "all model status should be success";
+
+
+load modelExplain.`/tmp/linearregression` WHERE `alg`="LinearRegression" as lr_model_explain;
+
+select `name` from lr_model_explain where name="uid" as result;
+
+!assert result ''':name=="uid"'''  "LinearRegression modelExplain should be successful";


### PR DESCRIPTION
# What changes were proposed in this pull request?
issue #1649 

# How was this patch tested?
1. Added it case 23_random_forest_model_explain.mlsql; updated linearRegression it case andie_huang_02_train_linear_regression_model.mlsql. 
2. Test result
All it cases runs in yarn-client mode ( hadoop3 ), and successfully finished.
```
SimpleQueryTestSuite:
22/07/10 11:46:32  INFO TestManager: collect test file: 01_hdfs_command_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 02_load_csv_file.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 03_process_data.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 04_save_to_delta.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 05_mlsql_assert_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 06_if_else_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 07_show_version_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 08_grammar_analyze_exception_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 09_run_json_expand_ext.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 09_syntax_analysis_ext_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 10_run_json_expand_ext.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 11_json_expand_ext_exception.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 13_project_include_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 13_run_rate_sampler.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 14_run_prediction_evaluation.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 15_gbt_classifier_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 16_gbt_regressor_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 17_discretizer_bucketizer_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 18_discretizer_quantile_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 19_feishu_messagge.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 20_nesting_variables_across_cells_test.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 21_java_udf_compile.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 22_scala_udf_compile.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: 23_random_forest_model_explain.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: andie_huang_01_train_logistic_regression_model.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: andie_huang_02_train_linear_regression_model.mlsql; matches=.*
22/07/10 11:46:32  INFO TestManager: collect test file: andie_huang_03_train_automl_extension.mlsql; matches=.*

Run completed in 2 minutes, 31 seconds.
Total number of tests run: 3
Suites: completed 3, aborted 0
Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
```

# Are there and DOC need to update?
No doc changes

# Spark Core Compatibility
Spark 2 & 3