### PR TITLE
Fix macOS jdk8 path in header.sh

### DIFF
--- a/dev/header.sh
+++ b/dev/header.sh
@@ -106,33 +106,37 @@ then
         export BYZER_SERVER_MODE="server"
     fi
 
-    # set JAVA
-    if [[ "${JAVA}" == "" ]]; then
-        if [[ -z "$JAVA_HOME" ]]; then
-            if [[ ${BYZER_SERVER_MODE} == "all-in-one" ]]; then
-                # use embeded open jdk 8 in all-in-one
-                JAVA_HOME=${BYZER_HOME}/jdk8
-            elif [[ $(isValidJavaVersion) == "true" ]]; then
-                JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))
-            else
-                quit "Java 1.8 or above is required."
-            fi
-            [[ -z "$JAVA_HOME" ]] && quit "Please set JAVA_HOME"
-            export JAVA_HOME
-        fi
-        export JAVA=$JAVA_HOME/bin/java
-        [[ -e "${JAVA}" ]] || quit "${JAVA} does not exist. Please set JAVA_HOME correctly."
-        verbose "java is ${JAVA}" 
-    fi
-    
-    # check Machine
-    unameOut="$(uname -s)"
-    case "${unameOut}" in
-        Linux*)     os=Linux;;
-        Darwin*)    os=Mac;;
-        CYGWIN*)    os=Cygwin;;
-        MINGW*)     os=MinGw;;
-        *)          os="UNKNOWN:${unameOut}"
-    esac
-    export MACHINE_OS=$os
+   # check Machine
+   unameOut="$(uname -s)"
+   case "${unameOut}" in
+       Linux*)     os=Linux;;
+       Darwin*)    os=Mac;;
+       CYGWIN*)    os=Cygwin;;
+       MINGW*)     os=MinGw;;
+       *)          os="UNKNOWN:${unameOut}"
+   esac
+   export MACHINE_OS=$os
+   # set JAVA
+   if [[ "${JAVA}" == "" ]]; then
+       if [[ -z "$JAVA_HOME" ]]; then
+           if [[ ${BYZER_SERVER_MODE} == "all-in-one" ]]; then
+               if [[ "Mac" == "${MACHINE_OS}" ]]
+               then
+                  # use embedded open jdk 8 in all-in-one
+                  JAVA_HOME=${BYZER_HOME}/jdk8/Contents/Home/
+               else
+                  JAVA_HOME="${BYZER_HOME}"/jdk8
+               fi
+           elif [[ $(isValidJavaVersion) == "true" ]]; then
+               JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))
+           else
+               quit "Java 1.8 or above is required."
+           fi
+           [[ -z "$JAVA_HOME" ]] && quit "Please set JAVA_HOME"
+           export JAVA_HOME
+       fi
+       export JAVA=$JAVA_HOME/bin/java
+       [[ -e "${JAVA}" ]] || quit "${JAVA} does not exist. Please set JAVA_HOME correctly."
+       verbose "java is ${JAVA}"
+   fi
 fi


### PR DESCRIPTION
# What changes were proposed in this pull request?
MacOS 下执行 byzer-lang  all-in-one 的 byzer.sh （实际上是 header.sh)  ，会查找 `jdk8/bin/java` 。而 MacOS byzer-lang all-ine-one 由于 [PR](https://github.com/byzer-org/byzer-cli/commit/910995c489b32f71e0c94b18337923d726106ec5) 修改目录结构为 `jdk8/Contents/Home/bin/java`  。 因此，header.sh 需要适配。

Internal jira issue Id :  BZ-1465

Linux 和 Windows 没有这一问题。

# How was this patch tested?
- [x] Testing done

在 relase-2.3.2 分支修改，随 byzer-lang 2.3.2 发布，且测试后，MacOS all-in-one 能执行 byzer.sh 
这一 PR 是 release-2.3.2 分支 cherry-pick 而来。

# Are there and DOC need to update?
- [x] Doc is finished

# Spark Core Compatibility
