### PR TITLE
允许用户自定义一个插件，该插件会在用户执行 load, save 以及 !hdfs/!fs 之前被执行

### DIFF
--- a/streamingpro-core/src/main/java/streaming/core/datasource/MLSQLSource.scala
+++ b/streamingpro-core/src/main/java/streaming/core/datasource/MLSQLSource.scala
@@ -57,11 +57,11 @@ trait RewritableSource {
 }
 
 trait RewritableSourceConfig {
-  def rewrite_0(config: DataSourceConfig, format: String,
-                context: MLSQLExecuteContext): DataSourceConfig
+  def rewrite_conf(config: DataSourceConfig, format: String,
+                   context: MLSQLExecuteContext): DataSourceConfig
 
-  def rewrite_1(sourceInfo: SourceInfo, format: String,
-                context: MLSQLExecuteContext): SourceInfo
+  def rewrite_source(sourceInfo: SourceInfo, format: String,
+                     context: MLSQLExecuteContext): SourceInfo
 }
 
 trait MLSQLSink extends MLSQLDataSource {
@@ -69,15 +69,15 @@ trait MLSQLSink extends MLSQLDataSource {
 }
 
 trait RewritableSinkConfig {
-  def rewrite_0(config: DataSinkConfig, format: String,
-                context: MLSQLExecuteContext): DataSinkConfig
+  def rewrite(config: DataSinkConfig, format: String,
+              context: MLSQLExecuteContext): DataSinkConfig
 }
 
 case class FSConfig(conf: Configuration, path: String, params: Map[String, String])
 
 trait RewritableFSConfig {
-  def rewrite_0(config: FSConfig,
-                context: MLSQLExecuteContext): FSConfig
+  def rewrite(config: FSConfig,
+              context: MLSQLExecuteContext): FSConfig
 }
 
 trait MLSQLDirectSource extends MLSQLDataSource {

--- a/streamingpro-core/src/main/java/streaming/core/datasource/MLSQLSource.scala
+++ b/streamingpro-core/src/main/java/streaming/core/datasource/MLSQLSource.scala
@@ -19,6 +19,7 @@
 package streaming.core.datasource
 
 import _root_.streaming.dsl.MLSQLExecuteContext
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql._
 
 /**
@@ -48,15 +49,35 @@ trait MLSQLSourceConfig {
   def skipDynamicEvaluation = false
 }
 
-trait RewriteableSource {
+trait RewritableSource {
   def rewrite(df: DataFrame,
               config: DataSourceConfig,
               sourceInfo: Option[SourceInfo],
               context: MLSQLExecuteContext): DataFrame
 }
 
+trait RewritableSourceConfig {
+  def rewrite_0(config: DataSourceConfig, format: String,
+                context: MLSQLExecuteContext): DataSourceConfig
+
+  def rewrite_1(sourceInfo: SourceInfo, format: String,
+                context: MLSQLExecuteContext): SourceInfo
+}
+
 trait MLSQLSink extends MLSQLDataSource {
   def save(writer: DataFrameWriter[Row], config: DataSinkConfig): Any
+}
+
+trait RewritableSinkConfig {
+  def rewrite_0(config: DataSinkConfig, format: String,
+                context: MLSQLExecuteContext): DataSinkConfig
+}
+
+case class FSConfig(conf: Configuration, path: String, params: Map[String, String])
+
+trait RewritableFSConfig {
+  def rewrite_0(config: FSConfig,
+                context: MLSQLExecuteContext): FSConfig
 }
 
 trait MLSQLDirectSource extends MLSQLDataSource {

--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/LoadAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/LoadAdaptor.scala
@@ -264,7 +264,7 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
       case Some(item) =>
         item.customClassItems.classNames.map { className =>
           val instance = Class.forName(className).newInstance().asInstanceOf[RewritableSourceConfig]
-          instance.rewrite_0(config, format, context)
+          instance.rewrite_conf(config, format, context)
         }.headOption.getOrElse(config)
       case None =>
         config
@@ -279,7 +279,7 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
       case Some(item) =>
         item.customClassItems.classNames.map { className =>
           val instance = Class.forName(className).newInstance().asInstanceOf[RewritableSourceConfig]
-          instance.rewrite_1(sourceInfo, format, context)
+          instance.rewrite_source(sourceInfo, format, context)
         }.headOption.getOrElse(sourceInfo)
       case None =>
         sourceInfo

--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/LoadAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/LoadAdaptor.scala
@@ -88,7 +88,7 @@ case class LoadStatement(raw: String, format: String, path: String, option: Map[
 
 class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
                      _option: Map[String, String],
-                     var path: String,
+                     var _path: String,
                      tableName: String,
                      format: String
                     ) extends DslTool {
@@ -98,7 +98,7 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
     var option = _option
     val tempDS = DataSourceRegistry.fetch(format, option)
 
-    if (tempDS.isDefined ) {
+    if (tempDS.isDefined) {
       // DataSource who is not MLSQLSourceConfig or if it's MLSQLSourceConfig then  skipDynamicEvaluation is false
       // should evaluate the v with dynamic expression
       if (tempDS.isInstanceOf[MLSQLSourceConfig] && !tempDS.asInstanceOf[MLSQLSourceConfig].skipDynamicEvaluation) {
@@ -110,15 +110,22 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
     }
 
     val reader = scriptSQLExecListener.sparkSession.read
-    reader.options(option)
-    path = TemplateMerge.merge(path, scriptSQLExecListener.env().toMap)
+    val tempPath = TemplateMerge.merge(_path, scriptSQLExecListener.env().toMap)
 
     def emptyDataFrame = {
       import sparkSession.implicits._
       Seq.empty[String].toDF("name")
     }
 
-    val dsConf = DataSourceConfig(cleanStr(path), option, Option(emptyDataFrame))
+    val dsConf = optionsRewrite(
+      AppRuntimeStore.LOAD_BEFORE_CONFIG_KEY,
+      DataSourceConfig(cleanStr(tempPath), option, Option(emptyDataFrame)),
+      format,
+      ScriptSQLExec.context())
+
+    val path = dsConf.path
+
+    reader.options(dsConf.config)
     var sourceInfo: Option[SourceInfo] = None
 
     DataSourceRegistry.fetch(format, option).map { datasource =>
@@ -128,7 +135,11 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
       // extract source info if the datasource is  MLSQLSourceInfo
       if (datasource.isInstanceOf[MLSQLSourceInfo]) {
         val authConf = DataAuthConfig(dsConf.path, dsConf.config)
-        sourceInfo = Option(datasource.asInstanceOf[MLSQLSourceInfo].sourceInfo(authConf))
+        sourceInfo = Option(sourceInfoRewrite(
+          AppRuntimeStore.LOAD_BEFORE_CONFIG_KEY,
+          datasource.asInstanceOf[MLSQLSourceInfo].sourceInfo(authConf),
+          format,
+          ScriptSQLExec.context()))
       }
       if (datasource.isInstanceOf[DatasourceAuth]) {
         datasource.asInstanceOf[DatasourceAuth].auth(dsConf.path, dsConf.config)
@@ -220,7 +231,7 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
       }
 
 
-      path = TemplateMerge.merge(path, scriptSQLExecListener.env().toMap)
+      //path = TemplateMerge.merge(path, scriptSQLExecListener.env().toMap)
     }
 
     table.createOrReplaceTempView(tableName)
@@ -237,11 +248,41 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
     if (rewrite && implClass != "") {
       val instance = Class.forName(implClass)
       instance.newInstance()
-        .asInstanceOf[RewriteableSource]
+        .asInstanceOf[RewritableSource]
         .rewrite(df, config, sourceInfo, context)
 
     } else {
       df
+    }
+  }
+
+  def optionsRewrite(orderKey: String,
+                     config: DataSourceConfig,
+                     format: String,
+                     context: MLSQLExecuteContext) = {
+    AppRuntimeStore.store.getLoadSave(orderKey) match {
+      case Some(item) =>
+        item.customClassItems.classNames.map { className =>
+          val instance = Class.forName(className).newInstance().asInstanceOf[RewritableSourceConfig]
+          instance.rewrite_0(config, format, context)
+        }.headOption.getOrElse(config)
+      case None =>
+        config
+    }
+  }
+
+  def sourceInfoRewrite(orderKey: String,
+                        sourceInfo: SourceInfo,
+                        format: String,
+                        context: MLSQLExecuteContext) = {
+    AppRuntimeStore.store.getLoadSave(orderKey) match {
+      case Some(item) =>
+        item.customClassItems.classNames.map { className =>
+          val instance = Class.forName(className).newInstance().asInstanceOf[RewritableSourceConfig]
+          instance.rewrite_1(sourceInfo, format, context)
+        }.headOption.getOrElse(sourceInfo)
+      case None =>
+        sourceInfo
     }
   }
 
@@ -256,7 +297,7 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
         item.customClassItems.classNames.foreach { className =>
           val instance = Class.forName(className)
           newDF = instance.newInstance()
-            .asInstanceOf[RewriteableSource]
+            .asInstanceOf[RewritableSource]
             .rewrite(df, config, sourceInfo, context)
         }
       case None =>

--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/LoadAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/LoadAdaptor.scala
@@ -29,6 +29,7 @@ import streaming.dsl.{MLSQLExecuteContext, ScriptSQLExec, ScriptSQLExecListener}
 import streaming.source.parser.impl.JsonSourceParser
 import streaming.source.parser.{SourceParser, SourceSchema}
 import tech.mlsql.MLSQLEnvKey
+import tech.mlsql.common.PathFun
 import tech.mlsql.dsl.auth.DatasourceAuth
 import tech.mlsql.runtime.AppRuntimeStore
 import tech.mlsql.sql.MLSQLSparkConf
@@ -151,7 +152,13 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
       // 1) fileSystem path; code example: load  modelExplain.`/tmp/model` where alg="RandomForest" as output;
       // 2) ET name; code example: load modelExample.`JsonExpandExt` AS output_1;  load modelParams.`JsonExpandExt` as output;
       // For FileSystem path, pass the real path to ModelSelfExplain; for ET name pass original path
-      val resourcePath = resourceRealPath(scriptSQLExecListener, option.get("owner"), path)
+      val _resourcePath = resourceRealPath(scriptSQLExecListener, option.get("owner"), path)
+
+      val resourcePath = dsConf.config.get("pathPrefix") match {
+        case Some(p) => PathFun.joinPath(p, _resourcePath)
+        case None => _resourcePath
+      }
+
       val fsPathOrETName = format match {
         case "modelExplain" => resourcePath
         case _ => cleanStr(path)

--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/LoadAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/LoadAdaptor.scala
@@ -29,7 +29,6 @@ import streaming.dsl.{MLSQLExecuteContext, ScriptSQLExec, ScriptSQLExecListener}
 import streaming.source.parser.impl.JsonSourceParser
 import streaming.source.parser.{SourceParser, SourceSchema}
 import tech.mlsql.MLSQLEnvKey
-import tech.mlsql.common.PathFun
 import tech.mlsql.dsl.auth.DatasourceAuth
 import tech.mlsql.runtime.AppRuntimeStore
 import tech.mlsql.sql.MLSQLSparkConf
@@ -152,13 +151,7 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
       // 1) fileSystem path; code example: load  modelExplain.`/tmp/model` where alg="RandomForest" as output;
       // 2) ET name; code example: load modelExample.`JsonExpandExt` AS output_1;  load modelParams.`JsonExpandExt` as output;
       // For FileSystem path, pass the real path to ModelSelfExplain; for ET name pass original path
-      val _resourcePath = resourceRealPath(scriptSQLExecListener, option.get("owner"), path)
-
-      val resourcePath = dsConf.config.get("pathPrefix") match {
-        case Some(p) => PathFun.joinPath(p, _resourcePath)
-        case None => _resourcePath
-      }
-
+      val resourcePath = resourceRealPath(scriptSQLExecListener, option.get("owner"), path)
       val fsPathOrETName = format match {
         case "modelExplain" => resourcePath
         case _ => cleanStr(path)
@@ -169,7 +162,7 @@ class LoadProcessing(scriptSQLExecListener: ScriptSQLExecListener,
     }
 
     table = customRewrite(AppRuntimeStore.LOAD_BEFORE_KEY, table, dsConf, sourceInfo, ScriptSQLExec.context())
-    // In order to control the access of columns, we should rewrite the final sql (conver * to specify column names)
+    // In order to control the access of columns, we should rewrite the final sql (convert * to specify column names)
     table = authRewrite(table, dsConf, sourceInfo, ScriptSQLExec.context())
     // finally use the  build-in or third-party plugins to rewrite the table.
     table = customRewrite(AppRuntimeStore.LOAD_AFTER_KEY, table, dsConf, sourceInfo, ScriptSQLExec.context())

--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/SaveAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/SaveAdaptor.scala
@@ -25,7 +25,6 @@ import streaming.core.stream.MLSQLStreamManager
 import streaming.dsl.parser.DSLSQLParser._
 import streaming.dsl.template.TemplateMerge
 import streaming.dsl.{MLSQLExecuteContext, ScriptSQLExec, ScriptSQLExecListener}
-import tech.mlsql.common.PathFun
 import tech.mlsql.job.{JobManager, MLSQLJobType}
 import tech.mlsql.runtime.AppRuntimeStore
 
@@ -149,12 +148,7 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
       if (path == "-" || path.isEmpty) {
         writer.format(option.getOrElse("implClass", format)).save()
       } else {
-        val _resourcePath = resourceRealPath(context.execListener, owner, path)
-        val resourcePath = option.get("pathPrefix") match {
-          case Some(p) => PathFun.joinPath(p, _resourcePath)
-          case None => _resourcePath
-        }
-        writer.format(option.getOrElse("implClass", format)).save( resourcePath )
+        writer.format(option.getOrElse("implClass", format)).save( resourceRealPath(context.execListener, owner, path) )
       }
     }
 

--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/SaveAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/SaveAdaptor.scala
@@ -183,7 +183,7 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
       case Some(item) =>
         item.customClassItems.classNames.map { className =>
           val instance = Class.forName(className).newInstance().asInstanceOf[RewritableSinkConfig]
-          instance.rewrite_0(config, format, context)
+          instance.rewrite(config, format, context)
         }.headOption.getOrElse(config)
       case None =>
         config

--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/SaveAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/SaveAdaptor.scala
@@ -25,6 +25,7 @@ import streaming.core.stream.MLSQLStreamManager
 import streaming.dsl.parser.DSLSQLParser._
 import streaming.dsl.template.TemplateMerge
 import streaming.dsl.{MLSQLExecuteContext, ScriptSQLExec, ScriptSQLExecListener}
+import tech.mlsql.common.PathFun
 import tech.mlsql.job.{JobManager, MLSQLJobType}
 import tech.mlsql.runtime.AppRuntimeStore
 
@@ -148,7 +149,12 @@ class SaveAdaptor(scriptSQLExecListener: ScriptSQLExecListener) extends DslAdapt
       if (path == "-" || path.isEmpty) {
         writer.format(option.getOrElse("implClass", format)).save()
       } else {
-        writer.format(option.getOrElse("implClass", format)).save(resourceRealPath(context.execListener, owner, path))
+        val _resourcePath = resourceRealPath(context.execListener, owner, path)
+        val resourcePath = option.get("pathPrefix") match {
+          case Some(p) => PathFun.joinPath(p, _resourcePath)
+          case None => _resourcePath
+        }
+        writer.format(option.getOrElse("implClass", format)).save( resourcePath )
       }
     }
 

--- a/streamingpro-core/src/main/java/tech/mlsql/runtime/AppRuntimeStore.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/runtime/AppRuntimeStore.scala
@@ -146,8 +146,13 @@ trait LoadSaveRuntimeStore {
 object AppRuntimeStore {
   private val _store = new InMemoryStore()
   val store = new AppRuntimeStore(_store)
+  val LOAD_BEFORE_CONFIG_KEY = "load_before_config_key"
+  val SAVE_BEFORE_CONFIG_KEY = "save_before_config_key"
+
   val LOAD_BEFORE_KEY = "load_before_key"
   val LOAD_AFTER_KEY = "load_after_key"
+
+  val FS_BEFORE_CONFIG_KEY = "fs_before_config_key"
 }
 
 class Jack extends CustomController {

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/ets/HDFSCommand.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/ets/HDFSCommand.scala
@@ -56,7 +56,7 @@ class HDFSCommand(override val uid: String) extends SQLAlg with Functions with W
       case Some(item) =>
         item.customClassItems.classNames.map { className =>
           val instance = Class.forName(className).newInstance().asInstanceOf[RewritableFSConfig]
-          instance.rewrite_0(config, context)
+          instance.rewrite(config, context)
         }.headOption.getOrElse(config)
       case None =>
         config

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/ets/HDFSCommand.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/ets/HDFSCommand.scala
@@ -4,15 +4,18 @@ import org.apache.hadoop.util.ToolRunner
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.mlsql.session.MLSQLException
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import streaming.core.datasource.{FSConfig, RewritableFSConfig}
 import streaming.dsl.mmlib.SQLAlg
 import streaming.dsl.mmlib.algs.Functions
 import streaming.dsl.mmlib.algs.param.{BaseParams, WowParams}
+import streaming.dsl.{MLSQLExecuteContext, ScriptSQLExec}
 import tech.mlsql.common.utils.serder.json.JSONTool
 import tech.mlsql.ets.hdfs.WowFsShell
+import tech.mlsql.runtime.AppRuntimeStore
 
 /**
-  * 2019-05-07 WilliamZhu(allwefantasy@gmail.com)
-  */
+ * 2019-05-07 WilliamZhu(allwefantasy@gmail.com)
+ */
 class HDFSCommand(override val uid: String) extends SQLAlg with Functions with WowParams {
   def this() = this(BaseParams.randomUID())
 
@@ -20,11 +23,12 @@ class HDFSCommand(override val uid: String) extends SQLAlg with Functions with W
 
   override def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
     val spark = df.sparkSession
-    val conf = df.sparkSession.sessionState.newHadoopConf()
+    val fsConf = configRewrite(AppRuntimeStore.FS_BEFORE_CONFIG_KEY,
+      FSConfig(df.sparkSession.sessionState.newHadoopConf(), path, params), ScriptSQLExec.context())
     val args = JSONTool.parseJson[List[String]](params("parameters"))
-    conf.setQuietMode(false)
+    fsConf.conf.setQuietMode(false)
     var output = ""
-    val fsShell = new WowFsShell(conf, path)
+    val fsShell = new WowFsShell(fsConf.conf, fsConf.path)
     try {
       ToolRunner.run(fsShell, args.toArray)
       output = fsShell.getError
@@ -42,6 +46,20 @@ class HDFSCommand(override val uid: String) extends SQLAlg with Functions with W
       spark.read.json(ds)
     } else {
       spark.createDataset[String](Seq(output)).toDF("fileSystem")
+    }
+  }
+
+  def configRewrite(orderKey: String,
+                    config: FSConfig,
+                    context: MLSQLExecuteContext): FSConfig = {
+    AppRuntimeStore.store.getLoadSave(orderKey) match {
+      case Some(item) =>
+        item.customClassItems.classNames.map { className =>
+          val instance = Class.forName(className).newInstance().asInstanceOf[RewritableFSConfig]
+          instance.rewrite_0(config, context)
+        }.headOption.getOrElse(config)
+      case None =>
+        config
     }
   }
 

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/DefaultLoaderPlugin.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/DefaultLoaderPlugin.scala
@@ -1,13 +1,13 @@
 package tech.mlsql.plugin.load
 
 import org.apache.spark.sql.DataFrame
-import streaming.core.datasource.{DataSourceConfig, RewriteableSource, SourceInfo}
+import streaming.core.datasource.{DataSourceConfig, RewritableSource, SourceInfo}
 import streaming.dsl.MLSQLExecuteContext
 
 /**
  * 11/12/2019 WilliamZhu(allwefantasy@gmail.com)
  */
-class DefaultLoaderPlugin extends RewriteableSource {
+class DefaultLoaderPlugin extends RewritableSource {
   override def rewrite(df: DataFrame, config: DataSourceConfig, sourceInfo: Option[SourceInfo], context: MLSQLExecuteContext): DataFrame = {
     val conf = config.config
     var table = df

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/MLSQLMultiBucket.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/MLSQLMultiBucket.scala
@@ -13,7 +13,7 @@ class MLSQLMultiBucketSource extends RewritableSourceConfig with Logging {
 
   private val supportedFormats = Set("csv", "json", "excel", "xml", "parquet")
 
-  override def rewrite_0(config: DataSourceConfig, format: String, context: MLSQLExecuteContext): DataSourceConfig = {
+  override def rewrite_conf(config: DataSourceConfig, format: String, context: MLSQLExecuteContext): DataSourceConfig = {
     if (context.execListener.env().getOrElse("fileSystemMode", "default") != "multiBucket") {
       return config
     }
@@ -32,7 +32,7 @@ class MLSQLMultiBucketSource extends RewritableSourceConfig with Logging {
     config.copy(path = PathFun.joinPath(pathPrefix, config.path))
   }
 
-  override def rewrite_1(sourceInfo: SourceInfo, format: String, context: MLSQLExecuteContext): SourceInfo = {
+  override def rewrite_source(sourceInfo: SourceInfo, format: String, context: MLSQLExecuteContext): SourceInfo = {
     sourceInfo
   }
 }
@@ -41,7 +41,7 @@ class MLSQLMultiBucketSink extends RewritableSinkConfig with Logging {
 
   private val supportedFormats = Set("csv", "json", "excel", "xml", "parquet")
 
-  override def rewrite_0(config: DataSinkConfig, format: String, context: MLSQLExecuteContext): DataSinkConfig = {
+  override def rewrite(config: DataSinkConfig, format: String, context: MLSQLExecuteContext): DataSinkConfig = {
     if (context.execListener.env().getOrElse("fileSystemMode", "default") != "multiBucket") {
       return config
     }
@@ -63,7 +63,7 @@ class MLSQLMultiBucketSink extends RewritableSinkConfig with Logging {
 
 class MLSQLMultiBucketFS extends RewritableFSConfig with Logging {
 
-  override def rewrite_0(config: FSConfig, context: MLSQLExecuteContext): FSConfig = {
+  override def rewrite(config: FSConfig, context: MLSQLExecuteContext): FSConfig = {
     if (context.execListener.env().getOrElse("fileSystemMode", "default") != "multiBucket") {
       return config
     }

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/MLSQLMultiBucket.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/MLSQLMultiBucket.scala
@@ -57,7 +57,7 @@ class MLSQLMultiBucketSink extends RewritableSinkConfig with Logging {
       MLSQLMultiBucket.configFS(options, context.execListener.sparkSession)
       pathPrefix = options("pathPrefix")
     })
-    config.copy(config.path, config.config + ("pathPrefix" -> pathPrefix))
+    config.copy(path = PathFun.joinPath(pathPrefix, config.path))
   }
 }
 

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/MLSQLMultiBucket.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/MLSQLMultiBucket.scala
@@ -1,0 +1,96 @@
+package tech.mlsql.plugin.load
+
+import org.apache.spark.sql.SparkSession
+import streaming.core.datasource._
+import streaming.dsl.{ConnectMeta, DBMappingKey, MLSQLExecuteContext}
+import tech.mlsql.common.utils.log.Logging
+import tech.mlsql.common.utils.path.PathFun
+
+/**
+ * 28/7/2022 WilliamZhu(allwefantasy@gmail.com)
+ */
+class MLSQLMultiBucketSource extends RewritableSourceConfig with Logging {
+
+  private val supportedFormats = Set("csv", "json", "excel", "xml", "parquet")
+
+  override def rewrite_0(config: DataSourceConfig, format: String, context: MLSQLExecuteContext): DataSourceConfig = {
+    if (context.execListener.env().getOrElse("fileSystemMode", "default") != "multiBucket") {
+      return config
+    }
+    if (!supportedFormats.contains(format)) {
+      logInfo(s"$format is not in supported list(${supportedFormats.mkString(",")}) ")
+      return config
+    }
+    val owner = context.owner
+
+    var pathPrefix = ""
+    // find the `connect` options and store them in session
+    ConnectMeta.presentThenCall(DBMappingKey("FS", owner), options => {
+      MLSQLMultiBucket.configFS(options, context.execListener.sparkSession)
+      pathPrefix = options("pathPrefix")
+    })
+    config.copy(path = PathFun.joinPath(pathPrefix, config.path))
+  }
+
+  override def rewrite_1(sourceInfo: SourceInfo, format: String, context: MLSQLExecuteContext): SourceInfo = {
+    sourceInfo
+  }
+}
+
+class MLSQLMultiBucketSink extends RewritableSinkConfig with Logging {
+
+  private val supportedFormats = Set("csv", "json", "excel", "xml", "parquet")
+
+  override def rewrite_0(config: DataSinkConfig, format: String, context: MLSQLExecuteContext): DataSinkConfig = {
+    if (context.execListener.env().getOrElse("fileSystemMode", "default") != "multiBucket") {
+      return config
+    }
+    if (!supportedFormats.contains(format)) {
+      logInfo(s"$format is not in supported list(${supportedFormats.mkString(",")}) ")
+      return config
+    }
+    val owner = context.owner
+
+    var pathPrefix = ""
+    // find the `connect` options and store them in session
+    ConnectMeta.presentThenCall(DBMappingKey("FS", owner), options => {
+      MLSQLMultiBucket.configFS(options, context.execListener.sparkSession)
+      pathPrefix = options("pathPrefix")
+    })
+    config.copy(path = PathFun.joinPath(pathPrefix, config.path))
+  }
+}
+
+class MLSQLMultiBucketFS extends RewritableFSConfig with Logging {
+
+  override def rewrite_0(config: FSConfig, context: MLSQLExecuteContext): FSConfig = {
+    if (context.execListener.env().getOrElse("fileSystemMode", "default") != "multiBucket") {
+      return config
+    }
+    val owner = context.owner
+    var pathPrefix = ""
+    // find the `connect` options and store them in session
+    ConnectMeta.presentThenCall(DBMappingKey("FS", owner), options => {
+      MLSQLMultiBucket.configFS(options, context.execListener.sparkSession)
+      pathPrefix = options("pathPrefix")
+    })
+    config.copy(path = PathFun.joinPath(pathPrefix, config.path))
+  }
+}
+
+object MLSQLMultiBucket {
+  def configFS(config: Map[String, String], session: SparkSession) = {
+    val (objectStoreConf, _) = config.partition(item => item._1.startsWith("spark.hadoop") || item._1.startsWith("fs."))
+
+    objectStoreConf.map { item =>
+      if (item._1.startsWith("fs.")) {
+        ("spark.hadoop." + item._1, item._2)
+      } else item
+    }.foreach(item => session.conf.set(item._1, item._2))
+    // To load azure blob data, spark.hadoop prefix should be removed. Because NativeAzureFileSystem - azure blob's HDFS
+    // compatible API, looks up Azure blob credentials by fs.azure.account.key.<account>.blob.core.chinacloudapi.cn.
+    objectStoreConf.filter(_._1.startsWith("spark.hadoop.fs.azure")).foreach { conf =>
+      session.conf.set(conf._1.replace("spark.hadoop.fs.azure", "fs.azure"), conf._2)
+    }
+  }
+}

--- a/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/MLSQLMultiBucket.scala
+++ b/streamingpro-mlsql/src/main/java/tech/mlsql/plugin/load/MLSQLMultiBucket.scala
@@ -29,7 +29,7 @@ class MLSQLMultiBucketSource extends RewritableSourceConfig with Logging {
       MLSQLMultiBucket.configFS(options, context.execListener.sparkSession)
       pathPrefix = options("pathPrefix")
     })
-    config.copy(path = PathFun.joinPath(pathPrefix, config.path))
+    config.copy(config.path, config.config + ("pathPrefix" -> pathPrefix))
   }
 
   override def rewrite_1(sourceInfo: SourceInfo, format: String, context: MLSQLExecuteContext): SourceInfo = {
@@ -57,7 +57,7 @@ class MLSQLMultiBucketSink extends RewritableSinkConfig with Logging {
       MLSQLMultiBucket.configFS(options, context.execListener.sparkSession)
       pathPrefix = options("pathPrefix")
     })
-    config.copy(path = PathFun.joinPath(pathPrefix, config.path))
+    config.copy(config.path, config.config + ("pathPrefix" -> pathPrefix))
   }
 }
 


### PR DESCRIPTION
# What changes were proposed in this pull request?

```
connect FS where 
`fs.s3a.endpoint`="s3.ap-northeast-3.amazonaws.com"
and `fs.s3a.impl`="org.apache.hadoop.fs.s3a.S3AFileSystem"
and `fs.s3a.access.key`="your access key"
and `fs.s3a.secret.key`="your secret key"
and `fs.s3a.buffer.dir`="/tmp/oss"
and `pathPrefix`="s3://dddd"
as allwefantasy;

set fileSystemMode="multiBucket";

load csv.`/tmp/a.csv`  as output;
!hdfs -ls /;
```

允许用户自定义一个插件，该插件会在用户执行 load, save 以及 !hdfs/!fs 之前被执行，用户可以改写这些语句的where 条件中的参数，这包括增加或者减少。

比如在上面的例子中，我提供了一个叫做 multiBucket 的示例实现，该实现会在执行load语句的时候，拿到connect 语句的配置参数，然后配置 spark引擎。同时获取 pathPrefix, 然后拼接用户传递的 `/tmp/a.csv` 路径，最后的真实执行路径是 `s3://dddd/tmp/a.csv`。同理当用户执行 !hdfs 的时候，也会做类似的工作。


用户可以在 App 类型的插件回调函数中通过如下方式注册：

```scala
AppRuntimeStore.store.registerLoadSave(AppRuntimeStore.LOAD_BEFORE_CONFIG_KEY, "tech.mlsql.plugin.load.MLSQLMultiBucketSource")
    AppRuntimeStore.store.registerLoadSave(AppRuntimeStore.SAVE_BEFORE_CONFIG_KEY, "tech.mlsql.plugin.load.MLSQLMultiBucketSink")
    AppRuntimeStore.store.registerLoadSave(AppRuntimeStore.FS_BEFORE_CONFIG_KEY, "tech.mlsql.plugin.load.MLSQLMultiBucketFS")
```
上面包含了一些示例实现。如果需要在 IDE 中测试，那么可以将上面三行代码放在启动类中：

![image](https://user-images.githubusercontent.com/797758/181493471-e8b95c8f-4fde-45ea-be42-12eb62185749.png)


# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
