### PR TITLE
add load and save rewriting config

### DIFF
--- a/streamingpro-core/src/main/java/tech/mlsql/runtime/PluginHook.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/runtime/PluginHook.scala
@@ -1,6 +1,5 @@
 package tech.mlsql.runtime
 
-import org.apache.spark.SparkCoreVersion
 import streaming.core.strategy.platform.{SparkRuntime, StreamingRuntime}
 import tech.mlsql.common.utils.classloader.ClassLoaderTool
 import tech.mlsql.common.utils.log.Logging
@@ -19,6 +18,22 @@ class PluginHook extends MLSQLPlatformLifecycle with Logging {
   override def afterRuntime(runtime: StreamingRuntime, params: Map[String, String]): Unit = {}
 
   override def beforeDispatcher(runtime: StreamingRuntime, params: Map[String, String]): Unit = {
+    params.getOrElse("streaming.plugin.builtin.load.before.config", "").
+      split(",").filterNot(_.isEmpty).
+      foreach { beforeItem =>
+        AppRuntimeStore.store.registerLoadSave(AppRuntimeStore.LOAD_BEFORE_CONFIG_KEY, beforeItem)
+      }
+
+    params.getOrElse("streaming.plugin.builtin.save.before.config", "").split(",").filterNot(_.isEmpty).
+      foreach { beforeItem =>
+        AppRuntimeStore.store.registerLoadSave(AppRuntimeStore.SAVE_BEFORE_CONFIG_KEY, beforeItem)
+      }
+
+    params.getOrElse("streaming.plugin.builtin.fs.before.config", "").split(",").filterNot(_.isEmpty).
+      foreach { beforeItem =>
+        AppRuntimeStore.store.registerLoadSave(AppRuntimeStore.FS_BEFORE_CONFIG_KEY, beforeItem)
+      }
+
     // build-in plugins
     params.getOrElse("streaming.plugin.buildin.loads.before", "").
       split(",").filterNot(_.isEmpty).
@@ -30,6 +45,7 @@ class PluginHook extends MLSQLPlatformLifecycle with Logging {
       foreach { afterItem =>
         AppRuntimeStore.store.registerLoadSave(AppRuntimeStore.LOAD_AFTER_KEY, afterItem)
       }
+
 
     // build-in plugins
     PluginHook.startBuildIn(


### PR DESCRIPTION
# What changes were proposed in this pull request?
- #1802 引入 hook 机制，允许用户 save/load 执行之前，添加一些逻辑。本PR 允许用户配置 hook，否则用户只能" 写死" hook。
在 conf/byzer.properties.override 添加以下配置。这里 `tech.mlsql.plugin.load.*` 是用户自定义的 hook，以支持多 S3 Bucket 。
```properties
streaming.plugin.builtin.load.before.config=tech.mlsql.plugin.load.MultiS3BucketSourcePlugin
streaming.plugin.builtin.save.before.config=tech.mlsql.plugin.load.MultiS3BucketSinkPlugin
streaming.plugin.builtin.fs.before.config=tech.mlsql.plugin.load.MultiS3BucketFSPlugin
```
 
# How was this patch tested?
## 测试结果
测试代码:
```
set path_prefix="/byzer-lang/";
set tenant_id = "abc";
select 1 as id AS dd;
save overwrite dd as parquet.`/tmp/dd`;
```

日志:
```
22/08/08 00:38:02  INFO DefaultMLSQLJobProgressListener: [owner] [admin] [groupId] [3152ac9a-7ec8-4fe8-9741-2a3534a73eab] __MMMMMM__ Total jobs: 1 current job:1 job script:save overwrite dd as parquet.`/tmp/dd`
22/08/08 00:38:02  INFO MultiS3Bucket: [owner] [admin] [groupId] [3152ac9a-7ec8-4fe8-9741-2a3534a73eab] __MMMMMM__ owner admin tenant_id abc
22/08/08 00:38:02  INFO MultiS3BucketSinkPlugin: [owner] [admin] [groupId] [3152ac9a-7ec8-4fe8-9741-2a3534a73eab] __MMMMMM__ Prepending path s3a://zjc-2//byzer-lang/
22/08/08 00:38:18  INFO FileOutputCommitter: Saved output of task 'attempt_202208080038117797996891790082632_0000_m_000000_0' to s3a://zjc-2/byzer-lang/tmp/dd/_temporary/0/task_202208080038117797996891790082632_0000_m_000000
```
检查 S3 bucket，数据已经写入。
![image](https://user-images.githubusercontent.com/12869649/183302251-36fe45a2-ab13-412c-9cad-2484fd07c88e.png)

测试所需额外Jar
- 用户自定义 hook jar，部署在 libs 子目录
- shade 后 hadoop-s3 jar aws-s3_3.2.0-1.0.0-SNAPSHOT.jar  见 byzer 下载站 http://dl-cdn.byzer.org/byzer/misc/cloud/s3/

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
