### PR TITLE
Remove MLSQLETApp ( mlsql-et-ets) from all-in-one

### DIFF
--- a/conf/byzer.properties.all-in-one.example
+++ b/conf/byzer.properties.all-in-one.example
@@ -12,4 +12,4 @@ streaming.job.cancel=true
 streaming.datalake.path=./data/
 streaming.driver.port=9003
 streaming.enableHiveSupport=false
-streaming.plugin.clzznames=tech.mlsql.plugins.ds.MLSQLExcelApp,tech.mlsql.plugins.assert.app.MLSQLAssert,tech.mlsql.plugins.shell.app.MLSQLShell,tech.mlsql.plugins.ext.ets.app.MLSQLETApp,tech.mlsql.plugins.mllib.app.MLSQLMllib
+streaming.plugin.clzznames=tech.mlsql.plugins.ds.MLSQLExcelApp,tech.mlsql.plugins.assert.app.MLSQLAssert,tech.mlsql.plugins.shell.app.MLSQLShell,tech.mlsql.plugins.mllib.app.MLSQLMllib


### PR DESCRIPTION
# What changes were proposed in this pull request?
Do not start MLSQLETApp ( mlsql-et-ets) in all-in-one

