### PR TITLE
upgrade commons-text to 1.10.0 to fix CVE-2022-42889

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <spark.bigversion>3.3</spark.bigversion>
         <scalatest.version>3.2.13</scalatest.version>
         <commons-codec.version>1.15</commons-codec.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <!-- spark 3.3 end -->
 
         <spark.streaming.kafka.artifactId>spark-streaming-kafka-0-8_${scala.binary.version}
@@ -130,6 +131,13 @@
                 <artifactId>jsoup</artifactId>
                 <version>${jsoup.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -373,6 +381,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
@@ -388,7 +397,6 @@
             <artifactId>commons-codec</artifactId>
             <version>${commons-codec.version}</version>
         </dependency>
-
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>


### PR DESCRIPTION
# What changes were proposed in this pull request?

1、漏洞概要：Apache Commons Text 项目实现了一系列关于文本字符串的算法，专注于处理字符串和文本块。2022年10月13日，Apache官方发布安全公告，修复了Apache Commons Text中的一个远程代码执行漏洞。漏洞编号：CVE-2022-42889。CNVD定义威胁等级为：高危。 该漏洞由于Apache Commons Text允许对文本进行相关的变量解析,攻击者可构造恶意文本，使得Apache Commons Text 在解析时执行任意代码，控制服务器。

2、受影响版本：1.5 <= Apache Commons Text <= 1.9

3、修复建议：当前官方已发布漏洞补丁，建议受影响的用户及时更新，安全版本为1.10.0。

# How was this patch tested?
- [x] Testing done

# Are there and DOC need to update?
- No docu change required

# Spark Core Compatibility
Spark 3.3.x