### PR TITLE
all-in-one to support java startup arguments

### DIFF
--- a/conf/byzer.properties
+++ b/conf/byzer.properties
@@ -17,9 +17,9 @@
 
 
 # byzer engine server mode
-# byzer engine provides two server mode
-# - all-in-one: which allows user run byzer engine in a local mode, with open-jdk1.8 and spark jars embeded, user do not need to configure the $SPARK_HOME
-# - server: the user need to specify an external $SPARK_HOME (3.1.1 or 2.4.3), the byzer engine will be started by spark-submit command 
+# byzer engine provides two modes
+# - all-in-one: which allows the user run byzer-lang in a local mode, with open-jdk1.8 and spark jars embedded, user do not need to configure the $SPARK_HOME
+# - server: the user needs to specify an external $SPARK_HOME (3.1.1 or 2.4.3), the byzer engine will be started by spark-submit command
 byzer.server.mode=server
 
 

--- a/conf/byzer.properties.all-in-one.example
+++ b/conf/byzer.properties.all-in-one.example
@@ -1,6 +1,7 @@
 # override example for all-in-one package
 
 byzer.server.mode=all-in-one
+byzer.server.extraJavaOptions=-Xmx4g -Xms512m -Xloggc:/tmp/byzer-gc-%p.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=200M -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintClassHistogramBeforeFullGC -XX:+PrintClassHistogramAfterFullGC -XX:+PrintGCApplicationStoppedTime
 
 streaming.master=local[*]
 streaming.name=Byzer-lang-desktop

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -135,8 +135,10 @@ function start(){
         echo "[All Config]"
         echo "${ALL_PROP}"
         echo ""
-        
-        nohup $JAVA -cp ${BYZER_HOME}/main/${MAIN_JAR}:${BYZER_HOME}/spark/*:${BYZER_HOME}/libs/*:${BYZER_HOME}/plugin/* \
+        java_options=$($BYZER_HOME/bin/get-properties.sh byzer.server.extraJavaOptions)
+
+        nohup $JAVA ${java_options} \
+            -cp ${BYZER_HOME}/main/${MAIN_JAR}:${BYZER_HOME}/spark/*:${BYZER_HOME}/libs/*:${BYZER_HOME}/plugin/* \
             tech.mlsql.example.app.LocalSparkServiceApp \
             $ALL_PROP >> ${BYZER_HOME}/logs/byzer.out &
         echo $! >> ${BYZER_HOME}/pid
@@ -152,13 +154,13 @@ function start(){
         echo "[Extra Config]"
         echo "${EXT_JARS}"
         echo ""
-
+        driver_java_options=$($BYZER_HOME/bin/get-properties.sh spark.driver.extraJavaOptions)
         nohup $SPARK_HOME/bin/spark-submit --class streaming.core.StreamingApp \
             --jars ${JARS} \
             --conf "spark.driver.extraClassPath=${EXT_JARS}" \
             --conf "spark.executor.extraClassPath=${EXT_JARS}" \
-            --driver-java-options "-Dlog4j.configurationFile=${BYZER_LOG_PATH}" \
             $SPARK_PROP \
+            --conf "spark.driver.extraJavaOptions=-Dlog4j2.configurationFile=${BYZER_LOG_PATH} ${driver_java_options}" \
             $MAIN_JAR_PATH  \
             $BYZER_PROP >> ${BYZER_HOME}/logs/byzer.out & 
         echo $! >> ${BYZER_HOME}/pid

--- a/dev/get-properties.sh
+++ b/dev/get-properties.sh
@@ -35,6 +35,6 @@ export SPARK_HOME=$BYZER_HOME/spark
 byzer_tools_log4j="${BYZER_HOME}/conf/byzer-tools-log4j2.properties"
 
 mkdir -p ${BYZER_HOME}/logs
-result=$(${JAVA} -Dlog4j.configurationFile=$byzer_tools_log4j -cp "${BYZER_HOME}/main/*" tech.mlsql.tool.ByzerConfigCLI $@ 2>>${BYZER_HOME}/logs/shell.stderr)
+result=$(${JAVA} -Dlog4j2.configurationFile=$byzer_tools_log4j -cp "${BYZER_HOME}/main/*" tech.mlsql.tool.ByzerConfigCLI $@ 2>>${BYZER_HOME}/logs/shell.stderr)
 
 echo "$result"


### PR DESCRIPTION
# What changes were proposed in this pull request?
#1890. This pr  introduces an option `byzer.server.extraJavaOptions` in byzer.properties.override for users to specify jvm options. An example is included as well. Note that `byzer.server.extraJavaOptions` does not work in server mode. 


# How was this patch tested?
- [x] Testing done
![image](https://user-images.githubusercontent.com/12869649/208226266-f2d16819-691b-4c25-b0ac-27a55c841fa6.png)


# Are there and DOC need to update?
- [x] Doc is finished

# Spark Core Compatibility
