### PR TITLE
添加hive类型方言的支持

### DIFF
--- a/streamingpro-core/src/main/java/streaming/core/strategy/platform/HiveJdbcDialect.scala
+++ b/streamingpro-core/src/main/java/streaming/core/strategy/platform/HiveJdbcDialect.scala
@@ -1,32 +1,52 @@
 package streaming.core.strategy.platform
 
-import org.apache.spark.sql.jdbc.JdbcDialect
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
+import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcType}
+import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, StringType}
 
 /**
-  * @Author: Alan
-  * @Time: 2018/12/18 17:43
-  * @Description:
-  */
+ * @Author: Alan
+ * @Time: 2018/12/18 17:43
+ * @Description:
+ */
 private case object HiveJdbcDialect extends JdbcDialect {
-  override def canHandle(url : String): Boolean = url.startsWith("jdbc:hive2")
+  override def canHandle(url: String): Boolean = url.startsWith("jdbc:hive2")
+
   override def quoteIdentifier(colName: String): String = {
-    val col =parseTableAndColFromStr(colName)
-    s"`$col`"
-  }
-  def parseTableAndColFromStr(str: String) = {
     var cleanedStr = ""
-    if (str.startsWith("`") || str.startsWith("\""))
-      cleanedStr = str.substring(1, str.length - 1)
+    if (colName.startsWith("`") || colName.startsWith("\""))
+      cleanedStr = colName.replace("`", "").replace("\"", "")
     else
-      cleanedStr = str
+      cleanedStr = colName
     val tableAndCol = cleanedStr.split("\\.")
     if (tableAndCol.length > 1) {
-      val table = tableAndCol(0)
-      val  col = tableAndCol.splitAt(1)._2.mkString(".")
-      col
+      tableAndCol.map(part => s"`$part`").mkString(".")
     } else {
-      cleanedStr
+      s"`$cleanedStr`"
     }
-
   }
+
+  /**
+   * Adapt to Hive data type definitions
+   * in https://cwiki.apache.org/confluence/display/hive/languagemanual+types .
+   *
+   * @param dt DataType in Spark SQL
+   * @return JdbcType with type definition adapted to Hive
+   */
+  override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
+    // [HIVE-14950] "INTEGER" is synonym for INT since Hive 2.2.0
+    // fallback to "INT" for better compatibility
+    case IntegerType => Option(JdbcType("INT", java.sql.Types.INTEGER))
+    // [HIVE-13556] "DOUBLE PRECISION" is alias for "DOUBLE" since Hive 2.2.0
+    // fallback to "DOUBLE" for better compatibility
+    case DoubleType => Option(JdbcType("DOUBLE", java.sql.Types.DOUBLE))
+    // adapt to Hive data type definition
+    case FloatType => Option(JdbcType("FLOAT", java.sql.Types.FLOAT))
+    case ByteType => Option(JdbcType("TINYINT", java.sql.Types.TINYINT))
+    case BooleanType => Option(JdbcType("BOOLEAN", java.sql.Types.BIT))
+    case StringType => Option(JdbcType("STRING", java.sql.Types.CLOB))
+    case BinaryType => Option(JdbcType("BINARY", java.sql.Types.BLOB))
+    case _ => JdbcUtils.getCommonJDBCType(dt)
+  }
+
 }


### PR DESCRIPTION
## 问题描述
执行save table1 as jdbc.`db.table` where url="jdbc:hive2://xxx" 语句是报错 
```
cannot recognize input near 'TEXT' ',' 'price' in column
```
具体的错误堆栈如下：
![img_v2_0b32496f-b006-4a1f-b1ff-1966b0c0189g](https://user-images.githubusercontent.com/20615623/211208187-5ea479fa-0809-4585-9c03-38ff9c154fb3.jpg)


## 问题分析
spark 生成hive sql需要生成类型，由下面函数实现，其中dialect.getJDBCType由于未实现使用了默认的dialect，导致类型错误：
```
  def getJdbcType(dt: DataType, dialect: JdbcDialect): JdbcType = {
    dialect.getJDBCType(dt).orElse(getCommonJDBCType(dt)).getOrElse(
      throw QueryExecutionErrors.cannotGetJdbcTypeError(dt))
  }
```