### PR TITLE
Configure byzer server by byzer.server.* in byzer shell script

### DIFF
--- a/conf/byzer.properties
+++ b/conf/byzer.properties
@@ -17,15 +17,13 @@
 
 
 # byzer engine server mode
-# byzer engine provides two server mode
-# - all-in-one: which allows user run byzer engine in a local mode, with open-jdk1.8 and spark jars embeded, user do not need to configure the $SPARK_HOME
-# - server: the user need to specify an external $SPARK_HOME (3.1.1 or 2.4.3), the byzer engine will be started by spark-submit command 
+# byzer engine provides two modes
+# - all-in-one: which allows the user run byzer-lang in a local mode, with open-jdk1.8 and spark jars embedded, user do not need to configure the $SPARK_HOME
+# - server: the user needs to specify an external $SPARK_HOME (3.1.1 or 2.4.3), the byzer engine will be started by spark-submit command
 byzer.server.mode=server
 
 
 # spark properties
-spark.master=local[*]
-spark.driver.memory=2g
 spark.sql.hive.thriftServer.singleSession=true
 spark.kryoserializer.buffer=256k
 spark.kryoserializer.buffer.max=1024m

--- a/conf/byzer.properties.all-in-one.example
+++ b/conf/byzer.properties.all-in-one.example
@@ -1,8 +1,11 @@
 # override example for all-in-one package
 
 byzer.server.mode=all-in-one
+byzer.server.dryrun=false
 
-streaming.master=local[*]
+## define Byzer Engine memory size
+byzer.server.runtime.driver-memory=6g
+
 streaming.name=Byzer-lang-desktop
 streaming.rest=true
 streaming.thrift=false

--- a/conf/byzer.properties.override
+++ b/conf/byzer.properties.override
@@ -1,4 +1,3 @@
-spark.master=local[*]
 streaming.name=byzer-lang
 streaming.rest=true
 streaming.platform=spark

--- a/conf/byzer.properties.server.example
+++ b/conf/byzer.properties.server.example
@@ -1,8 +1,18 @@
 # override example for server package
 
 byzer.server.mode=server
+byzer.server.dryrun=false
 
-streaming.master=local[*]
+# submit byzer server as yarn-client mode
+byzer.server.runtime.master=yarn
+byzer.server.runtime.deploy-mode=client
+
+# configure resource for yarn mode
+byzer.server.runtime.dirver-memory=6g
+byzer.server.runtime.executor-memory=4g
+byzer.server.runtime.executor-cores=4
+byzer.server.runtime.num-executors=4
+
 streaming.name=Byzer-lang-server
 streaming.rest=true
 streaming.thrift=false

--- a/dev/get-properties.sh
+++ b/dev/get-properties.sh
@@ -17,14 +17,14 @@
 # limitations under the License.
 #
 
-if [ $# != 1 ]
-then
-    if [[ $# -lt 2 || $2 != 'DEC' ]]
-        then
-            echo 'invalid input'
-            exit 1
-    fi
-fi
+#if [ $# != 1 ]
+#then
+#    if [[ $# -lt 2 || $2 != 'DEC' ]]
+#        then
+#            echo 'invalid input'
+#            exit 1
+#    fi
+#fi
 
 if [ -z $BYZER_HOME ];then
     export BYZER_HOME=$(cd -P -- "$(dirname -- "$0")"/../ && pwd -P)
@@ -35,6 +35,7 @@ export SPARK_HOME=$BYZER_HOME/spark
 byzer_tools_log4j="${BYZER_HOME}/conf/byzer-tools-log4j2.properties"
 
 mkdir -p ${BYZER_HOME}/logs
-result=$(${JAVA} -Dlog4j.configurationFile=$byzer_tools_log4j -cp "${BYZER_HOME}/main/*" tech.mlsql.tool.ByzerConfigCLI $@ 2>>${BYZER_HOME}/logs/shell.stderr)
+
+result=$(${JAVA} -Dlog4j2.configurationFile=$byzer_tools_log4j -cp "${BYZER_HOME}/main/*" tech.mlsql.tool.ByzerConfigCLI $@ 2>>${BYZER_HOME}/logs/shell.stderr)
 
 echo "$result"

--- a/streamingpro-commons/src/main/java/tech/mlsql/tool/ByzerConfigCLI.java
+++ b/streamingpro-commons/src/main/java/tech/mlsql/tool/ByzerConfigCLI.java
@@ -95,7 +95,7 @@ public class ByzerConfigCLI {
             // get byzer properties
             for (Map.Entry<Object, Object> entry : config.entrySet()) {
                 String entryKey = (String) entry.getKey();
-                if (entryKey.startsWith("streaming") || entryKey.startsWith("spark.mlsql")) {
+                if (entryKey.startsWith("streaming")) {
                     String prop = String.format(BYZER_CONF_TEMP, entryKey, entry.getValue());
                     System.out.println(prop);
                 }
@@ -104,7 +104,7 @@ public class ByzerConfigCLI {
             // get spark properties
             for (Map.Entry<Object, Object> entry : config.entrySet()) {
                 String entryKey = (String) entry.getKey();
-                if (entryKey.startsWith("spark") && !entryKey.startsWith("spark.mlsql")) {
+                if (entryKey.startsWith("spark")) {
                     String prop = String.format(SPARK_CONF_TEMP, entryKey, entry.getValue());
                     System.out.println(prop);
                 }

--- a/streamingpro-commons/src/main/java/tech/mlsql/tool/ByzerConfigCLI.java
+++ b/streamingpro-commons/src/main/java/tech/mlsql/tool/ByzerConfigCLI.java
@@ -19,6 +19,7 @@
 package tech.mlsql.tool;
 
 import com.google.common.collect.Maps;
+import tech.mlsql.common.utils.shell.command.ParamsUtil;
 
 import java.util.Map;
 import java.util.Objects;
@@ -37,21 +38,59 @@ public class ByzerConfigCLI {
         Unsafe.systemExit(0);
     }
 
+    public static void failOutput() {
+        System.out.println("Usage: ByzerConfigCLI conf_name");
+        System.out.println("Example: ByzerConfigCLI byzer.server.mode");
+        Unsafe.systemExit(1);
+    }
+
     public static void execute(String[] args) {
+
+        if (args.length == 0) {
+            failOutput();
+        }
+
+        Properties config = ByzerConfig.getInstance().getProperties();
+
+        if (args[0].trim().equals("_")) {
+            // copy a new array from old array except the first element
+            String[] newArgs = new String[args.length - 1];
+            for (int i = 1; i < args.length; i++) {
+                newArgs[i - 1] = args[i];
+            }
+            // BYZER_RUNTIME_PARAMS=$($BYZER_HOME/bin/get-properties.sh _ -prefix byzer.server.runtime. -type runtime)
+            ParamsUtil params = new ParamsUtil(newArgs);
+            String prefix = params.getParam("prefix");
+            String tpe = params.getParam("type", "runtime");
+
+            if (prefix != null) {
+                Map<String, String> props = getPropertiesByPrefix(config, prefix);
+                for (Map.Entry<String, String> prop : props.entrySet()) {
+                    if (tpe.equals("runtime")) {
+                        String[] keyArray = prop.getKey().split("\\.");
+                        String lastElement = keyArray[keyArray.length - 1];
+                        System.out.println("--" + lastElement + " " + prop.getValue().trim());
+                    } else {
+                        System.out.println(prop.getKey() + "=" + prop.getValue().trim());
+                    }
+
+                }
+                return;
+            }
+        }
+
         boolean needDec = false;
         if (args.length != 1) {
             if (args.length < 2 || !Objects.equals(EncryptUtil.DEC_FLAG, args[1])) {
-                System.out.println("Usage: ByzerConfigCLI conf_name");
-                System.out.println("Example: ByzerConfigCLI byzer.server.mode");
-                Unsafe.systemExit(1);
+                failOutput();
             } else {
                 needDec = true;
             }
         }
 
-        Properties config = ByzerConfig.getInstance().getProperties();
 
         String key = args[0].trim();
+
         if (key.equals("-byzer")) {
             // get byzer properties
             for (Map.Entry<Object, Object> entry : config.entrySet()) {
@@ -78,8 +117,7 @@ public class ByzerConfigCLI {
                 prop.append(String.format(ARGS_CONF_TEMP, entryKey, entry.getValue()));
             }
             System.out.println(prop);
-        }
-        else if (!key.endsWith(".")) {
+        } else if (!key.endsWith(".")) {
             String value = config.getProperty(key);
             if (value == null) {
                 value = "";


### PR DESCRIPTION
# What changes were proposed in this pull request?
Adding some new configuration in conf/byzer.properties.overwrite and modify the example of the property files.

For example, with the configuration like following:

```
byzer.server.mode=server
byzer.server.dryrun=false

# submit byzer server as yarn-client mode
byzer.server.runtime.master=yarn
byzer.server.runtime.deploy-mode=client

# configure resource for yarn mode
byzer.server.runtime.driver-memory=6g
byzer.server.runtime.executor-memory=4g
byzer.server.runtime.executor-cores=4
byzer.server.runtime.num-executors=4

```

When the user run `./bin/byzer.sh start`, the byzer will be submitted to yarn with client mode and the byzer server memory is 6g.

# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
