### PR TITLE
save支持设置config

### DIFF
--- a/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/DslAdaptor.scala
+++ b/streamingpro-core/src/main/java/tech/mlsql/dsl/adaptor/DslAdaptor.scala
@@ -173,4 +173,15 @@ trait DslTool {
 
     Array(dbName, finalPath)
   }
+
+  /**
+   * The `runtime.hadoop` prefix is used to set spark multiple options, and the prefix is removed globally and set to options.
+   * @param runtimeOptions the runtime hadoop options
+   * @return
+   */
+  def cleanRuntimeOptionsPrefix(runtimeOptions: Map[String, String]): Map[String, String] = {
+    runtimeOptions.map { item =>
+      (item._1.replace("runtime.hadoop.", ""), item._2)
+    }
+  }
 }


### PR DESCRIPTION
如下spark支持设置DF的options配置：
```
//Example to set multiple options
df.write.options(Map("header"->"true"))
        . csv("file-path")
```
save需要支持该方式，通过SQL设置：
```
save overwrite newAccessTable as csv.`file-path` where runtime.hadoop.header="true";
```
其中的 `runtime.hadoop.`  为spark通用options配置前缀。
