### PR TITLE
Catch ToolBoxError in ScalaRuntimeCompileUDF

### DIFF
--- a/streamingpro-it/src/test/resources/sql/all_mode/core/core_udaf01_scala.byzer
+++ b/streamingpro-it/src/test/resources/sql/all_mode/core/core_udaf01_scala.byzer
@@ -1,0 +1,50 @@
+--%exception=java.util.concurrent.ExecutionException
+--%msg=scala\.tools\.reflect\.ToolBoxError: reflective compilation has failed:[\n]+(.*?)[\n]?(.*?)
+
+
+-- Error in line 16. va should be val
+set plusFun='''
+import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+class SumAggregation extends UserDefinedAggregateFunction with Serializable{
+    def inputSchema: StructType = new StructType().add("a", LongType)
+    def bufferSchema: StructType =  new StructType().add("total", LongType)
+    def dataType: DataType = LongType
+    def deterministic: Boolean = true
+    def initialize(buffer: MutableAggregationBuffer): Unit = {
+      buffer.update(0, 0l)
+    }
+    def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+      val sum   = buffer.getLong(0)
+      va newitem = input.getLong(0)
+      buffer.update(0, sum + newitem)
+    }
+    def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+      buffer1.update(0, buffer1.getLong(0) + buffer2.getLong(0))
+    }
+    def evaluate(buffer: Row): Any = {
+      buffer.getLong(0)
+    }
+}
+''';
+
+
+--加载脚本
+load script.`plusFun` as scriptTable;
+--注册为UDF函数 名称为plusFun
+register ScriptUDF.`scriptTable` as plusFun options
+className="SumAggregation"
+and udfType="udaf"
+;
+
+set data='''
+{"a":1}
+{"a":1}
+{"a":1}
+{"a":1}
+''';
+load jsonStr.`data` as dataTable;
+
+-- 使用plusFun
+select a,plusFun(a) as res from dataTable group by a as output;

--- a/streamingpro-it/src/test/resources/sql/all_mode/core/core_udf04_scala.byzer
+++ b/streamingpro-it/src/test/resources/sql/all_mode/core/core_udf04_scala.byzer
@@ -1,0 +1,12 @@
+--%exception=java.lang.IllegalArgumentException
+--%msg=UDF Compilation error: reflective typecheck has failed: object a is not a member of package hhhh
+Register ScriptUDF.`` AS plusFun
+WHERE lang='scala'
+AND udfType="udf"
+AND code='''
+  def apply(a: Double, b: Double) = {
+      hhhh a + b
+  }
+''';
+
+select plusFun(1.0,2.0) as a;

--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
@@ -24,12 +24,11 @@ import _root_.streaming.dsl.{MLSQLExecuteContext, ScriptSQLExec, ScriptSQLExecLi
 import _root_.streaming.log.WowLog
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import net.csdn.annotation.rest.{At, _}
+import net.csdn.annotation.rest._
 import net.csdn.common.collections.WowCollections
 import net.csdn.modules.http.ApplicationController
 import net.csdn.modules.http.RestRequest.Method._
-import org.apache.http.HttpStatus
-import org.apache.http.HttpResponse
+import org.apache.http.{HttpResponse, HttpStatus}
 import org.apache.spark.ps.cluster.Message
 import org.apache.spark.ps.cluster.Message.Pong
 import org.apache.spark.sql._
@@ -38,9 +37,8 @@ import org.apache.spark.sql.mlsql.session.{MLSQLSparkSession, SparkSessionCacheM
 import org.apache.spark.{MLSQLConf, SparkInstanceService}
 import tech.mlsql.MLSQLEnvKey
 import tech.mlsql.app.{CustomController, ResultResp}
-import tech.mlsql.common.utils.serder.json.JsonUtils
 import tech.mlsql.common.utils.log.Logging
-import tech.mlsql.common.utils.serder.json.JSONTool
+import tech.mlsql.common.utils.serder.json.{JSONTool, JsonUtils}
 import tech.mlsql.crawler.RestUtils
 import tech.mlsql.crawler.RestUtils.executeWithRetrying
 import tech.mlsql.job.{JobManager, MLSQLJobType}


### PR DESCRIPTION
# What changes were proposed in this pull request?
Fixes issue #1915 


# How was this patch tested?
Running erroneous scalaUDF returns a error-message.

![image](https://user-images.githubusercontent.com/12869649/227753014-3043337d-3f44-48f4-9cd5-22571b708e1f.png)

A it case : `core_udf04_scala.scala` is added as well.

# Are there and DOC need to update?
No doc change

# Spark Core Compatibility
