### PR TITLE
Scope SQLConf of session.active

### DIFF
--- a/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/rest/RestController.scala
@@ -405,11 +405,13 @@ class RestController extends ApplicationController with WowLog with Logging {
       runtime.asInstanceOf[SparkRuntime].sparkSession
     }
 
-    if (paramAsBoolean("sessionPerRequest", false)) {
+    val _session = if (paramAsBoolean("sessionPerRequest", false)) {
       MLSQLSparkSession.cloneSession(session)
     } else {
       session
     }
+    SparkSession.setActiveSession(_session)
+    _session
   }
 
   def getSessionByOwner(owner: String) = {


### PR DESCRIPTION
# What changes were proposed in this pull request?
Set activeSession before each script execution. Because spark `functions.expr` use SQLConf of activeSession. 
Refer to [SPARK-44206](https://issues.apache.org/jira/browse/SPARK-44206), all SparkSession dataset methods already covered by withActive, but `functions` still only use SQLConf of active SparkSession.
# How was this patch tested?
Refer to [SPARK-44206](https://issues.apache.org/jira/browse/SPARK-44206)
# Are there and DOC need to update?
Unnecessary
# Spark Core Compatibility
