### PR TITLE
fix driver-memory spelling error

### DIFF
--- a/conf/byzer.properties.server.example
+++ b/conf/byzer.properties.server.example
@@ -8,7 +8,7 @@ byzer.server.runtime.master=yarn
 byzer.server.runtime.deploy-mode=client
 
 # configure resource for yarn mode
-byzer.server.runtime.dirver-memory=6g
+byzer.server.runtime.driver-memory=6g
 byzer.server.runtime.executor-memory=4g
 byzer.server.runtime.executor-cores=4
 byzer.server.runtime.num-executors=4


### PR DESCRIPTION
# What changes were proposed in this pull request?
- [ ] byzer.server.runtime.driver-memory is writen as  byzer.server.runtime.dirver-memory config file byzer.properties.server.example led to server start fail

# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] No

# Spark Core Compatibility
